### PR TITLE
fix: mouse range for non-standard resolutions

### DIFF
--- a/src/uinput/mouse.cpp
+++ b/src/uinput/mouse.cpp
@@ -133,8 +133,8 @@ void Mouse::move(int delta_x, int delta_y) {
 }
 
 void Mouse::move_abs(int x, int y, int screen_width, int screen_height) {
-  int scaled_x = (int)std::lround((ABS_MAX_WIDTH / screen_width) * x);
-  int scaled_y = (int)std::lround((ABS_MAX_HEIGHT / screen_height) * y);
+  int scaled_x = (int)std::lround((ABS_MAX_WIDTH / (double)screen_width) * x);
+  int scaled_y = (int)std::lround((ABS_MAX_HEIGHT / (double)screen_height) * y);
 
   if (auto mouse = _state->mouse_abs.get()) {
     libevdev_uinput_write_event(mouse, EV_ABS, ABS_X, scaled_x);

--- a/tests/testLibinput.cpp
+++ b/tests/testLibinput.cpp
@@ -153,6 +153,19 @@ TEST_CASE("virtual mouse absolue", "[LIBINPUT]") {
         REQUIRE_THAT(libinput_event_pointer_get_absolute_x_transformed(p_event, TARGET_WIDTH),
                      WithinRel(TARGET_WIDTH, 0.5f));
     }
+
+    {// Testing non 16:9 aspect ratio (PR-9)
+      TARGET_WIDTH = 19200;
+      TARGET_HEIGHT = 10800;
+      mouse.move_abs(TARGET_WIDTH, TARGET_HEIGHT, TARGET_WIDTH, TARGET_HEIGHT);
+      event = get_event(li);
+      REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_POINTER_MOTION_ABSOLUTE);
+      auto p_event = libinput_event_get_pointer_event(event.get());
+      REQUIRE_THAT(libinput_event_pointer_get_absolute_y_transformed(p_event, TARGET_HEIGHT),
+                   WithinRel(TARGET_HEIGHT, 0.001f));
+      REQUIRE_THAT(libinput_event_pointer_get_absolute_x_transformed(p_event, TARGET_WIDTH),
+                   WithinRel(TARGET_WIDTH, 0.001f));
+    }
 }
 
 TEST_CASE("virtual touch screen", "[LIBINPUT]") {


### PR DESCRIPTION
When using a non-standard resolution (i.e. 19200 not divisible by width and/or 10800 not divisible by height), the mouse is not able to move to the bottom right corner, because integer division is performed.