### PR TITLE
fix: always set pen pressure/distance

### DIFF
--- a/src/uinput/pentablet.cpp
+++ b/src/uinput/pentablet.cpp
@@ -129,11 +129,13 @@ void PenTablet::place_tool(
     if (pressure >= 0) {
       int scaled_pressure = (int)std::lround(pressure * PRESSURE_MAX);
       libevdev_uinput_write_event(tablet, EV_ABS, ABS_PRESSURE, scaled_pressure);
+      libevdev_uinput_write_event(tablet, EV_ABS, ABS_DISTANCE, 0);
     }
 
     if (distance >= 0) {
       int scaled_distance = (int)std::lround(distance * DISTANCE_MAX);
       libevdev_uinput_write_event(tablet, EV_ABS, ABS_DISTANCE, scaled_distance);
+      libevdev_uinput_write_event(tablet, EV_ABS, ABS_PRESSURE, 0);
     }
 
     auto scaled_tilt_x = std::clamp(tilt_x, -90.0f, 90.0f);

--- a/src/uinput/pentablet.cpp
+++ b/src/uinput/pentablet.cpp
@@ -129,12 +129,14 @@ void PenTablet::place_tool(
     if (pressure >= 0) {
       int scaled_pressure = (int)std::lround(pressure * PRESSURE_MAX);
       libevdev_uinput_write_event(tablet, EV_ABS, ABS_PRESSURE, scaled_pressure);
+      // when there's pressure, the tool must be touching the tablet
       libevdev_uinput_write_event(tablet, EV_ABS, ABS_DISTANCE, 0);
     }
 
     if (distance >= 0) {
       int scaled_distance = (int)std::lround(distance * DISTANCE_MAX);
       libevdev_uinput_write_event(tablet, EV_ABS, ABS_DISTANCE, scaled_distance);
+      // when there's distance, the tool can't be touching the tablet
       libevdev_uinput_write_event(tablet, EV_ABS, ABS_PRESSURE, 0);
     }
 

--- a/tests/testLibinput.cpp
+++ b/tests/testLibinput.cpp
@@ -312,6 +312,20 @@ TEST_CASE("virtual pen tablet", "[LIBINPUT]") {
         REQUIRE(libinput_event_tablet_tool_get_tip_state(t_event) == LIBINPUT_TABLET_TOOL_TIP_DOWN);
     }
 
+    { // Try removing the pen by setting the distance to 1.0
+      tablet.place_tool(PenTablet::PEN, 0.1, 0.2, -1, 1.0, 45, 25);
+      event = get_event(li);
+      std::cout << libinput_event_get_type(event.get()) << std::endl;
+      REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_TABLET_TOOL_TIP);
+      auto t_event = libinput_event_get_tablet_tool_event(event.get());
+      REQUIRE(libinput_event_tablet_tool_get_proximity_state(t_event) == LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_IN);
+      REQUIRE(libinput_tablet_tool_get_type(libinput_event_tablet_tool_get_tool(t_event)) ==
+              LIBINPUT_TABLET_TOOL_TYPE_PEN);
+      REQUIRE(libinput_event_tablet_tool_get_distance(t_event) == 1.0);
+      REQUIRE(libinput_event_tablet_tool_get_pressure(t_event) == 0.0);
+      REQUIRE(libinput_event_tablet_tool_get_tip_state(t_event) == LIBINPUT_TABLET_TOOL_TIP_UP);
+    }
+
     { // Test out pressing a button on the tool
         tablet.set_btn(PenTablet::PRIMARY, true);
         event = get_event(li);


### PR DESCRIPTION
Some applications only depend on pressure (e.g. Xournal++), and hence the pen doesn't always 'release' when the pen is hovering. This is because the application completely disregards ABS_DISTANCE and only looks at ABS_PRESSURE, which contains the last updated pressure, which was when the pen was still touching.

This fixes the second part of https://github.com/LizardByte/Sunshine/issues/2756.