### PR TITLE
Implementing virtual DualSense over Bluetooth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,12 @@ if (UNIX AND NOT APPLE)
             "src/uinput/joypad_utils.hpp"
             "src/uhid/joypad_ps5.cpp")
     target_include_directories(libinputtino PUBLIC "src/uinput/include" "src/uhid/include/")
+
+    # Find zlib libraries
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(ZLIB REQUIRED IMPORTED_TARGET zlib)
+
+    target_link_libraries(libinputtino PUBLIC PkgConfig::ZLIB)
 endif ()
 
 if (BUILD_SERVER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,12 +115,6 @@ if (UNIX AND NOT APPLE)
             "src/uinput/joypad_utils.hpp"
             "src/uhid/joypad_ps5.cpp")
     target_include_directories(libinputtino PUBLIC "src/uinput/include" "src/uhid/include/")
-
-    # Find zlib libraries
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(ZLIB REQUIRED IMPORTED_TARGET zlib)
-
-    target_link_libraries(libinputtino PUBLIC PkgConfig::ZLIB)
 endif ()
 
 if (BUILD_SERVER)

--- a/include/inputtino/input.hpp
+++ b/include/inputtino/input.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace inputtino {
@@ -432,6 +433,7 @@ protected:
   std::shared_ptr<PS5JoypadState> _state;
 
 private:
+  std::thread _send_input_thread;
   PS5Joypad(uint16_t vendor_id);
 };
 } // namespace inputtino

--- a/src/uhid/include/crc32.hpp
+++ b/src/uhid/include/crc32.hpp
@@ -1,8 +1,38 @@
+/**
+ * Adapted from https://gist.github.com/timepp/1f678e200d9e0f2a043a9ec6b3690635
+ * uses constexpr to generate a CRC32 table at compile time
+ */
 #pragma once
 
+#include <array>
 #include <cstdint>
-#include <zlib.h>
 
-inline uint32_t CRC32(const unsigned char *buffer, size_t length, uint32_t seed = 0) {
-  return crc32_z(seed, buffer, length);
+static constexpr auto generate_table(std::uint32_t polynomial = 0xEDB88320) {
+  std::array<std::uint32_t, 256> table{};
+  for (std::uint32_t i = 0; i < 256; i++) {
+    std::uint32_t c = i;
+    for (std::size_t j = 0; j < 8; j++) {
+      if (c & 1) {
+        c = polynomial ^ (c >> 1);
+      } else {
+        c >>= 1;
+      }
+    }
+    table[i] = c;
+  }
+  return table;
+}
+
+// Static lookup table generated at compile time
+static constexpr auto lookup_table = generate_table();
+
+/**
+ * Calculate the CRC32 of a buffer
+ */
+static constexpr uint32_t CRC32(const unsigned char *buffer, uint32_t length, uint32_t seed = 0) {
+  uint32_t c = seed ^ 0xFFFFFFFF;
+  for (size_t i = 0; i < length; ++i) {
+    c = lookup_table[(c ^ buffer[i]) & 0xFF] ^ (c >> 8);
+  }
+  return c ^ 0xFFFFFFFF;
 }

--- a/src/uhid/include/crc32.hpp
+++ b/src/uhid/include/crc32.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <cstdint>
+#include <zlib.h>
+
+inline uint32_t CRC32(const unsigned char *buffer, size_t length, uint32_t seed = 0) {
+  return crc32_z(seed, buffer, length);
+}

--- a/src/uhid/include/uhid/protected_types.hpp
+++ b/src/uhid/include/uhid/protected_types.hpp
@@ -17,15 +17,15 @@ struct PS5JoypadState {
    * We also use this information internally to unique match a device with the
    * /dev/input/devXX files; see get_nodes()
    */
-  unsigned char mac_address[6] = {
-      0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF
-  };
+  unsigned char mac_address[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
   uint16_t vendor_id;
 
-  uhid::dualsense_input_report_usb current_state;
+  uhid::dualsense_input_report current_state = {};
   uint8_t last_touch_id = 0;
 
   std::optional<std::function<void(int, int)>> on_rumble = std::nullopt;
   std::optional<std::function<void(int, int, int)>> on_led = std::nullopt;
+  bool stop_repeat_thread = false;
+  bool is_bluetooth = true;
 };
 } // namespace inputtino

--- a/src/uhid/include/uhid/ps5.hpp
+++ b/src/uhid/include/uhid/ps5.hpp
@@ -2,6 +2,7 @@
 
 #include <linux/uhid.h>
 #include <vector>
+#include <crc32.hpp>
 
 namespace uhid {
 
@@ -28,8 +29,11 @@ static constexpr float SDL_STANDARD_GRAVITY = 9.80665f;
  * https://github.com/torvalds/linux/blob/305230142ae0637213bf6e04f6d9f10bbcb74af8/drivers/hid/hid-playstation.c#L70-L72
  */
 static constexpr unsigned char PS_INPUT_CRC32_SEED = 0xA1;
+static constexpr auto PS_INPUT_CRC32= CRC32(&PS_INPUT_CRC32_SEED, 1);
 static constexpr unsigned char PS_OUTPUT_CRC32_SEED = 0xA2;
+static constexpr auto PS_OUTPUT_CRC32 = CRC32(&PS_OUTPUT_CRC32_SEED, 1);
 static constexpr unsigned char PS_FEATURE_CRC32_SEED = 0xA3;
+static constexpr auto PS_FEATURE_CRC32 = CRC32(&PS_FEATURE_CRC32_SEED, 1);
 
 /**
  * Taken from: https://github.com/nondebug/dualsense/blob/main/report-descriptor-usb.txt

--- a/src/uhid/include/uhid/ps5.hpp
+++ b/src/uhid/include/uhid/ps5.hpp
@@ -23,6 +23,14 @@ static constexpr int PS5_TOUCHPAD_WIDTH = 1920;
 static constexpr int PS5_TOUCHPAD_HEIGHT = 1080;
 static constexpr float SDL_STANDARD_GRAVITY = 9.80665f;
 
+/*
+ * Bluetooth constants,
+ * https://github.com/torvalds/linux/blob/305230142ae0637213bf6e04f6d9f10bbcb74af8/drivers/hid/hid-playstation.c#L70-L72
+ */
+static constexpr unsigned char PS_INPUT_CRC32_SEED = 0xA1;
+static constexpr unsigned char PS_OUTPUT_CRC32_SEED = 0xA2;
+static constexpr unsigned char PS_FEATURE_CRC32_SEED = 0xA3;
+
 /**
  * Taken from: https://github.com/nondebug/dualsense/blob/main/report-descriptor-usb.txt
  * and verified manually using hid-decode
@@ -164,6 +172,146 @@ static constexpr unsigned char ps5_rdesc[] = {
     0xC0,             // End Collection
 };
 
+/**
+ * Taken from https://github.com/nondebug/dualsense/blob/main/report-descriptor-bluetooth.txt
+ */
+static constexpr unsigned char ps5_rdesc_bt[] = {
+    0x05, 0x01,       // Usage Page (Generic Desktop Ctrls)
+    0x09, 0x05,       // Usage (Game Pad)
+    0xA1, 0x01,       // Collection (Application)
+    0x85, 0x01,       //   Report ID (1)
+    0x09, 0x30,       //   Usage (X)
+    0x09, 0x31,       //   Usage (Y)
+    0x09, 0x32,       //   Usage (Z)
+    0x09, 0x35,       //   Usage (Rz)
+    0x15, 0x00,       //   Logical Minimum (0)
+    0x26, 0xFF, 0x00, //   Logical Maximum (255)
+    0x75, 0x08,       //   Report Size (8)
+    0x95, 0x04,       //   Report Count (4)
+    0x81, 0x02,       //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x09, 0x39,       //   Usage (Hat switch)
+    0x15, 0x00,       //   Logical Minimum (0)
+    0x25, 0x07,       //   Logical Maximum (7)
+    0x35, 0x00,       //   Physical Minimum (0)
+    0x46, 0x3B, 0x01, //   Physical Maximum (315)
+    0x65, 0x14,       //   Unit (System: English Rotation, Length: Centimeter)
+    0x75, 0x04,       //   Report Size (4)
+    0x95, 0x01,       //   Report Count (1)
+    0x81, 0x42,       //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,Null State)
+    0x65, 0x00,       //   Unit (None)
+    0x05, 0x09,       //   Usage Page (Button)
+    0x19, 0x01,       //   Usage Minimum (0x01)
+    0x29, 0x0E,       //   Usage Maximum (0x0E)
+    0x15, 0x00,       //   Logical Minimum (0)
+    0x25, 0x01,       //   Logical Maximum (1)
+    0x75, 0x01,       //   Report Size (1)
+    0x95, 0x0E,       //   Report Count (14)
+    0x81, 0x02,       //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x75, 0x06,       //   Report Size (6)
+    0x95, 0x01,       //   Report Count (1)
+    0x81, 0x01,       //   Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x05, 0x01,       //   Usage Page (Generic Desktop Ctrls)
+    0x09, 0x33,       //   Usage (Rx)
+    0x09, 0x34,       //   Usage (Ry)
+    0x15, 0x00,       //   Logical Minimum (0)
+    0x26, 0xFF, 0x00, //   Logical Maximum (255)
+    0x75, 0x08,       //   Report Size (8)
+    0x95, 0x02,       //   Report Count (2)
+    0x81, 0x02,       //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x06, 0x00, 0xFF, //   Usage Page (Vendor Defined 0xFF00)
+    0x15, 0x00,       //   Logical Minimum (0)
+    0x26, 0xFF, 0x00, //   Logical Maximum (255)
+    0x75, 0x08,       //   Report Size (8)
+    0x95, 0x4D,       //   Report Count (77)
+    0x85, 0x31,       //   Report ID (49)
+    0x09, 0x31,       //   Usage (0x31)
+    0x91, 0x02,       //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x09, 0x3B,       //   Usage (0x3B)
+    0x81, 0x02,       //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x85, 0x32,       //   Report ID (50)
+    0x09, 0x32,       //   Usage (0x32)
+    0x95, 0x8D,       //   Report Count (-115)
+    0x91, 0x02,       //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x33,       //   Report ID (51)
+    0x09, 0x33,       //   Usage (0x33)
+    0x95, 0xCD,       //   Report Count (-51)
+    0x91, 0x02,       //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x34,       //   Report ID (52)
+    0x09, 0x34,       //   Usage (0x34)
+    0x96, 0x0D, 0x01, //   Report Count (269)
+    0x91, 0x02,       //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x35,       //   Report ID (53)
+    0x09, 0x35,       //   Usage (0x35)
+    0x96, 0x4D, 0x01, //   Report Count (333)
+    0x91, 0x02,       //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x36,       //   Report ID (54)
+    0x09, 0x36,       //   Usage (0x36)
+    0x96, 0x8D, 0x01, //   Report Count (397)
+    0x91, 0x02,       //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x37,       //   Report ID (55)
+    0x09, 0x37,       //   Usage (0x37)
+    0x96, 0xCD, 0x01, //   Report Count (461)
+    0x91, 0x02,       //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x38,       //   Report ID (56)
+    0x09, 0x38,       //   Usage (0x38)
+    0x96, 0x0D, 0x02, //   Report Count (525)
+    0x91, 0x02,       //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x39,       //   Report ID (57)
+    0x09, 0x39,       //   Usage (0x39)
+    0x96, 0x22, 0x02, //   Report Count (546)
+    0x91, 0x02,       //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x06, 0x80, 0xFF, //   Usage Page (Vendor Defined 0xFF80)
+    0x85, 0x05,       //   Report ID (5)
+    0x09, 0x33,       //   Usage (0x33)
+    0x95, 0x28,       //   Report Count (40)
+    0xB1, 0x02,       //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x08,       //   Report ID (8)
+    0x09, 0x34,       //   Usage (0x34)
+    0x95, 0x2F,       //   Report Count (47)
+    0xB1, 0x02,       //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x09,       //   Report ID (9)
+    0x09, 0x24,       //   Usage (0x24)
+    0x95, 0x13,       //   Report Count (19)
+    0xB1, 0x02,       //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x20,       //   Report ID (32)
+    0x09, 0x26,       //   Usage (0x26)
+    0x95, 0x3F,       //   Report Count (63)
+    0xB1, 0x02,       //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x22,       //   Report ID (34)
+    0x09, 0x40,       //   Usage (0x40)
+    0x95, 0x3F,       //   Report Count (63)
+    0xB1, 0x02,       //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x80,       //   Report ID (-128)
+    0x09, 0x28,       //   Usage (0x28)
+    0x95, 0x3F,       //   Report Count (63)
+    0xB1, 0x02,       //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x81,       //   Report ID (-127)
+    0x09, 0x29,       //   Usage (0x29)
+    0x95, 0x3F,       //   Report Count (63)
+    0xB1, 0x02,       //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x82,       //   Report ID (-126)
+    0x09, 0x2A,       //   Usage (0x2A)
+    0x95, 0x09,       //   Report Count (9)
+    0xB1, 0x02,       //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0x83,       //   Report ID (-125)
+    0x09, 0x2B,       //   Usage (0x2B)
+    0x95, 0x3F,       //   Report Count (63)
+    0xB1, 0x02,       //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0xF1,       //   Report ID (-15)
+    0x09, 0x31,       //   Usage (0x31)
+    0x95, 0x3F,       //   Report Count (63)
+    0xB1, 0x02,       //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0xF2,       //   Report ID (-14)
+    0x09, 0x32,       //   Usage (0x32)
+    0x95, 0x0F,       //   Report Count (15)
+    0xB1, 0x02,       //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x85, 0xF0,       //   Report ID (-16)
+    0x09, 0x30,       //   Usage (0x30)
+    0x95, 0x3F,       //   Report Count (63)
+    0xB1, 0x02,       //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,             // End Collection
+};
+
 enum PS5_REPORT_TYPES : unsigned int {
   CALIBRATION = 0x05,
   PAIRING_INFO = 0x09,
@@ -222,6 +370,7 @@ static constexpr unsigned char ps5_pairing_info[] = {
     0x1E, 0x00, 0xEE, 0x74, 0xD0, 0xBC, 0x00, 0x00, 0x00, 0x00,
 };
 
+#pragma pack(push, 1)
 struct dualsense_touch_point {
   /*
    * Status of a DualShock4 touch point contact.
@@ -277,8 +426,18 @@ enum HAT_STATES : uint8_t {
   HAT_NW = 0x7
 };
 
-struct dualsense_input_report_usb {
+struct dualsense_input_report_usb_header {
   uint8_t report_id = 0x01;
+};
+
+struct dualsense_input_report_bt_header {
+  uint8_t report_id = 0x31;
+  uint8_t reserved;
+};
+
+constexpr size_t PS_INPUT_REPORT_BT_OFFSET = 13;
+
+struct dualsense_input_report {
   uint8_t x, y = PS5_AXIS_NEUTRAL;   // LS
   uint8_t rx, ry = PS5_AXIS_NEUTRAL; // RS
   uint8_t z, rz = PS5_AXIS_NEUTRAL;  // L2, R2
@@ -326,11 +485,10 @@ enum FLAG2 : uint8_t {
   COMPATIBLE_VIBRATION = 0x04
 };
 
-struct dualsense_output_report_usb {
-  uint8_t report_id; // 0x02 for USB
-
-  uint8_t valid_flag0; // see enum FLAG0
-  uint8_t valid_flag1; // see enum FLAG1
+/* Common data between DualSense BT/USB main output report. */
+struct dualsense_output_report_common {
+  uint8_t valid_flag0;
+  uint8_t valid_flag1;
 
   /* For DualShock 4 compatibility mode. */
   uint8_t motor_right;
@@ -344,7 +502,7 @@ struct dualsense_output_report_usb {
   uint8_t reserved2[28];
 
   /* LEDs and lightbar */
-  uint8_t valid_flag2; // see enum FLAG2
+  uint8_t valid_flag2;
   uint8_t reserved3[2];
   uint8_t lightbar_setup;
   uint8_t led_brightness;
@@ -352,7 +510,25 @@ struct dualsense_output_report_usb {
   uint8_t lightbar_red;
   uint8_t lightbar_green;
   uint8_t lightbar_blue;
-
-  uint8_t reserved4[15];
 };
+
+static constexpr uint8_t DS_OUTPUT_REPORT_USB = 0x02;
+
+struct dualsense_output_report_usb {
+  uint8_t report_id; /* 0x02 */
+  struct dualsense_output_report_common common;
+  uint8_t reserved[15];
+};
+
+static constexpr uint8_t DS_OUTPUT_REPORT_BT = 0x31;
+
+struct dualsense_output_report_bt {
+  uint8_t report_id; /* 0x31 */
+  uint8_t seq_tag;
+  struct dualsense_output_report_common common;
+  uint8_t reserved[24];
+  __le32 crc32;
+};
+#pragma pack(pop)
+
 } // namespace uhid

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -186,10 +186,13 @@ template <typename T> std::string to_hex(T i) {
 
 std::string PS5Joypad::get_mac_address() const {
   std::stringstream stream;
-  stream << std::hex << std::setfill('0') << std::setw(2) //
-         << (unsigned int)_state->mac_address[0] << ":" << (unsigned int)_state->mac_address[1] << ":"
-         << (unsigned int)_state->mac_address[2] << ":" << (unsigned int)_state->mac_address[3] << ":"
-         << (unsigned int)_state->mac_address[4] << ":" << (unsigned int)_state->mac_address[5];
+  stream << std::hex << std::setfill('0')
+         << std::setw(2) << (unsigned int)_state->mac_address[0] << ":"
+         << std::setw(2) << (unsigned int)_state->mac_address[1] << ":"
+         << std::setw(2) << (unsigned int)_state->mac_address[2] << ":"
+         << std::setw(2) << (unsigned int)_state->mac_address[3] << ":"
+         << std::setw(2) << (unsigned int)_state->mac_address[4] << ":"
+         << std::setw(2) << (unsigned int)_state->mac_address[5];
   return stream.str();
 }
 

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -14,9 +14,8 @@
 
 namespace inputtino {
 
-static uint32_t sign_crc32(const unsigned char seed, const unsigned char *buffer, size_t length) {
-  auto crc = CRC32(&seed, 1);
-  crc = CRC32(buffer, length, crc);
+static uint32_t sign_crc32(uint32_t seed, const unsigned char *buffer, size_t length) {
+  auto crc = CRC32(buffer, length, seed);
   crc = htole32(crc); // Convert to little endian
   return crc;
 }
@@ -65,7 +64,7 @@ static void send_report(PS5JoypadState &state) {
     ev.u.input2.size += uhid::PS_INPUT_REPORT_BT_OFFSET;
 
     auto end_of_msg = ev.u.input2.size - 4; // (Last 4 bytes contains crc32)
-    auto crc = sign_crc32(uhid::PS_INPUT_CRC32_SEED, &ev.u.input2.data[0], end_of_msg);
+    auto crc = sign_crc32(uhid::PS_INPUT_CRC32, &ev.u.input2.data[0], end_of_msg);
     std::copy(reinterpret_cast<unsigned char *>(&crc),
               reinterpret_cast<unsigned char *>(&crc) + 4,
               &ev.u.input2.data[end_of_msg]);
@@ -117,7 +116,7 @@ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, 
     if (state->is_bluetooth) {
       // CRC32 encode the data and append it to the reply
       auto end_of_msg = answer.u.get_report_reply.size - 4; // (Last 4 bytes contains crc32)
-      auto crc = sign_crc32(uhid::PS_FEATURE_CRC32_SEED, &answer.u.get_report_reply.data[0], end_of_msg);
+      auto crc = sign_crc32(uhid::PS_FEATURE_CRC32, &answer.u.get_report_reply.data[0], end_of_msg);
       std::copy(reinterpret_cast<unsigned char *>(&crc),
                 reinterpret_cast<unsigned char *>(&crc) + 4,
                 &answer.u.get_report_reply.data[end_of_msg]);

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <climits>
 #include <cmath>
+#include <crc32.hpp>
 #include <endian.h>
 #include <filesystem>
 #include <fstream>
@@ -12,6 +13,13 @@
 #include <uhid/uhid.hpp>
 
 namespace inputtino {
+
+static uint32_t sign_crc32(const unsigned char seed, const unsigned char *buffer, size_t length) {
+  auto crc = CRC32(&seed, 1);
+  crc = CRC32(buffer, length, crc);
+  crc = htole32(crc); // Convert to little endian
+  return crc;
+}
 
 static void send_report(PS5JoypadState &state) {
   { // setup timestamp and increase seq_number
@@ -28,13 +36,41 @@ static void send_report(PS5JoypadState &state) {
     state.current_state.sensor_timestamp = htole32(now / 333);
   }
 
-  struct uhid_event ev {};
+  struct uhid_event ev{};
   {
     ev.type = UHID_INPUT2;
+
+    std::size_t header_size;
+    if (state.is_bluetooth) {
+      auto header = uhid::dualsense_input_report_bt_header{};
+      header_size = sizeof(header);
+      std::copy(reinterpret_cast<unsigned char *>(&header),
+                reinterpret_cast<unsigned char *>(&header) + header_size,
+                &ev.u.input2.data[0]);
+    } else {
+      auto header = uhid::dualsense_input_report_usb_header{};
+      header_size = sizeof(header);
+      std::copy(reinterpret_cast<unsigned char *>(&header),
+                reinterpret_cast<unsigned char *>(&header) + header_size,
+                &ev.u.input2.data[0]);
+    }
+
     unsigned char *data = (unsigned char *)&state.current_state;
-    std::copy(data, data + sizeof(state.current_state), &ev.u.input2.data[0]);
-    ev.u.input2.size = sizeof(state.current_state);
+    std::copy(data, data + sizeof(state.current_state), &ev.u.input2.data[header_size]);
+
+    ev.u.input2.size = header_size + sizeof(state.current_state);
   }
+
+  if (state.is_bluetooth) { // CRC32 encode the data and append it to the reply
+    ev.u.input2.size += uhid::PS_INPUT_REPORT_BT_OFFSET;
+
+    auto end_of_msg = ev.u.input2.size - 4; // (Last 4 bytes contains crc32)
+    auto crc = sign_crc32(uhid::PS_INPUT_CRC32_SEED, &ev.u.input2.data[0], end_of_msg);
+    std::copy(reinterpret_cast<unsigned char *>(&crc),
+              reinterpret_cast<unsigned char *>(&crc) + 4,
+              &ev.u.input2.data[end_of_msg]);
+  }
+
   state.dev->send(ev);
 }
 
@@ -77,25 +113,45 @@ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, 
       answer.u.get_report_reply.err = -EINVAL;
       break;
     }
+
+    if (state->is_bluetooth) {
+      // CRC32 encode the data and append it to the reply
+      auto end_of_msg = answer.u.get_report_reply.size - 4; // (Last 4 bytes contains crc32)
+      auto crc = sign_crc32(uhid::PS_FEATURE_CRC32_SEED, &answer.u.get_report_reply.data[0], end_of_msg);
+      std::copy(reinterpret_cast<unsigned char *>(&crc),
+                reinterpret_cast<unsigned char *>(&crc) + 4,
+                &answer.u.get_report_reply.data[end_of_msg]);
+    }
+
     auto res = uhid::uhid_write(fd, &answer);
     // TODO: signal error somehow
     break;
   }
   case UHID_OUTPUT: { // This is sent if the HID device driver wants to send raw data to the device
     // Here is where we'll get Rumble and LED events
-    uhid::dualsense_output_report_usb *report = (uhid::dualsense_output_report_usb *)ev.u.output.data;
+    // Check the first byte to see if it's a USB or BT report
+    uint8_t report_type = ev.u.output.data[0];
+    uhid::dualsense_output_report_common report;
+    if (report_type == uhid::DS_OUTPUT_REPORT_USB) {
+      auto report_usb = (uhid::dualsense_output_report_usb *)ev.u.output.data;
+      report = report_usb->common;
+    } else {
+      auto report_bt = (uhid::dualsense_output_report_bt *)ev.u.output.data;
+      report = report_bt->common;
+    }
+
     /*
      * RUMBLE
      * The PS5 joypad seems to report values in the range 0-255,
      * we'll turn those into 0-0xFFFF
      */
-    if (report->valid_flag0 & uhid::MOTOR_OR_COMPATIBLE_VIBRATION || report->valid_flag2 & uhid::COMPATIBLE_VIBRATION) {
-      auto left = (report->motor_left / 255.0f) * 0xFFFF;
-      auto right = (report->motor_right / 255.0f) * 0xFFFF;
+    if (report.valid_flag0 & uhid::MOTOR_OR_COMPATIBLE_VIBRATION || report.valid_flag2 & uhid::COMPATIBLE_VIBRATION) {
+      auto left = (report.motor_left / 255.0f) * 0xFFFF;
+      auto right = (report.motor_right / 255.0f) * 0xFFFF;
       if (state->on_rumble) {
         (*state->on_rumble)(left, right);
       }
-    } else if (report->valid_flag0 == 0 && report->valid_flag1 == 0 && report->valid_flag2 == 0) {
+    } else if (report.valid_flag0 == 0 && report.valid_flag1 == 0 && report.valid_flag2 == 0) {
       // Seems to be a special stop rumble event, let's propagate it
       if (state->on_rumble) {
         (*state->on_rumble)(0, 0);
@@ -105,10 +161,10 @@ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, 
     /*
      * LED
      */
-    if (report->valid_flag1 & uhid::LIGHTBAR_ENABLE) {
+    if (report.valid_flag1 & uhid::LIGHTBAR_ENABLE) {
       if (state->on_led) {
         // TODO: should we blend brightness?
-        (*state->on_led)(report->lightbar_red, report->lightbar_green, report->lightbar_blue);
+        (*state->on_led)(report.lightbar_red, report.lightbar_green, report.lightbar_blue);
       }
     }
   }
@@ -138,22 +194,33 @@ PS5Joypad::PS5Joypad(uint16_t vendor_id) : _state(std::make_shared<PS5JoypadStat
 
 PS5Joypad::~PS5Joypad() {
   if (this->_state && this->_state->dev) {
+    this->_state->stop_repeat_thread = true;
+    if (this->_send_input_thread.joinable()) {
+      this->_send_input_thread.join();
+    }
     this->_state->dev->stop_thread();
     this->_state->dev.reset(); // Will trigger ~Device and ultimately destroy the device
   }
 }
 
 Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device) {
+  bool use_bluetooth = true; // TODO: expose this
+
   auto def = uhid::DeviceDefinition{
       .name = device.name,
       .phys = device.device_phys,
       .uniq = device.device_uniq,
-      .bus = BUS_USB,
+      .bus = BUS_BLUETOOTH,
       .vendor = static_cast<uint32_t>(device.vendor_id),
       .product = static_cast<uint32_t>(device.product_id),
       .version = static_cast<uint32_t>(device.version),
       .country = 0,
-      .report_description = {&uhid::ps5_rdesc[0], &uhid::ps5_rdesc[0] + sizeof(uhid::ps5_rdesc)}};
+      .report_description = {&uhid::ps5_rdesc_bt[0], &uhid::ps5_rdesc_bt[0] + sizeof(uhid::ps5_rdesc_bt)}};
+
+  if (!use_bluetooth) {
+    def.bus = BUS_USB;
+    def.report_description = {&uhid::ps5_rdesc[0], &uhid::ps5_rdesc[0] + sizeof(uhid::ps5_rdesc)};
+  }
 
   auto joypad = PS5Joypad(device.vendor_id);
 
@@ -167,7 +234,18 @@ Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device) {
   auto dev =
       uhid::Device::create(def, [state = joypad._state](uhid_event ev, int fd) { on_uhid_event(state, ev, fd); });
   if (dev) {
+    joypad._state->is_bluetooth = use_bluetooth;
     joypad._state->dev = std::make_shared<uhid::Device>(std::move(*dev));
+
+    // Readers will expect frequent events event if the state hasn't changed
+    joypad._send_input_thread = std::thread([state = joypad._state]() {
+      while (!state->stop_repeat_thread) {
+        send_report(*state);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      }
+    });
+    joypad._send_input_thread.detach();
+
     return joypad;
   }
   return Error(dev.getErrorMessage());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(FetchContent)
+
 # Testing library
 FetchContent_Declare(
         Catch2

--- a/tests/testJoypads.cpp
+++ b/tests/testJoypads.cpp
@@ -577,8 +577,8 @@ TEST_CASE_METHOD(SDLTestsFixture, "Nintendo Joypad", "[SDL]") {
 
 TEST_CASE("Bluetooth CRC32", "[PS]") {
   std::string buffer = "123456789";
-  auto crc = CRC32(reinterpret_cast<unsigned char *>(buffer.data()), buffer.length());
-  REQUIRE(crc == 0xcbf43926);
+  auto crc = CRC32(reinterpret_cast<const unsigned char *>(buffer.data()), buffer.length());
+  REQUIRE(crc == 0xcbf43926); // https://crccalc.com/?crc=123456789&method=CRC-32/ISO-HDLC&datatype=ascii&outtype=hex
 
   unsigned char PS_INPUT_CRC32_SEED = 0xA1;
   auto crc2 = CRC32(&PS_INPUT_CRC32_SEED, 1, 0xFFFFFFFF);

--- a/tests/testJoypads.cpp
+++ b/tests/testJoypads.cpp
@@ -173,27 +173,6 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL],[PS]") {
     REQUIRE(rumble_data->second == 0x7878);
   }
 
-  { // LED
-    REQUIRE(SDL_GameControllerHasLED(gc));
-    struct LED {
-      int r;
-      int g;
-      int b;
-    };
-    auto led_data = std::make_shared<LED>();
-    joypad.set_on_led([led_data](int r, int g, int b) {
-      led_data->r = r;
-      led_data->g = g;
-      led_data->b = b;
-    });
-    SDL_GameControllerSetLED(gc, 50, 100, 150);
-    // TODO: doesn't work
-    // std::this_thread::sleep_for(100ms); // wait for the effect to be picked up
-    // REQUIRE(led_data->r == 50);
-    // REQUIRE(led_data->g == 100);
-    // REQUIRE(led_data->b == 150);
-  }
-
   test_buttons(gc, joypad);
   { // Sticks
     REQUIRE(SDL_GameControllerHasAxis(gc, SDL_CONTROLLER_AXIS_LEFTX));
@@ -344,6 +323,26 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL],[PS]") {
     flush_sdl_events();
   }
 
+  { // LED TODO: seems that this only works after some gyro/acceleration data is sent
+    REQUIRE(SDL_GameControllerHasLED(gc));
+    struct LED {
+      int r;
+      int g;
+      int b;
+    };
+    auto led_data = std::make_shared<LED>();
+    joypad.set_on_led([led_data](int r, int g, int b) {
+      led_data->r = r;
+      led_data->g = g;
+      led_data->b = b;
+    });
+    REQUIRE(SDL_GameControllerSetLED(gc, 50, 100, 150) == 0);
+    std::this_thread::sleep_for(20ms); // wait for the effect to be picked up
+    REQUIRE(led_data->r == 50);
+    REQUIRE(led_data->g == 100);
+    REQUIRE(led_data->b == 150);
+  }
+
   { // Test touchpad
     REQUIRE(SDL_GameControllerGetNumTouchpads(gc) == 1);
     REQUIRE(SDL_GameControllerGetNumTouchpadFingers(gc, 0) == 2);
@@ -357,8 +356,7 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL],[PS]") {
 
   { // Test battery
     auto joy = SDL_GameControllerGetJoystick(gc);
-    auto level = SDL_JoystickCurrentPowerLevel(joy);
-    REQUIRE(level == SDL_JOYSTICK_POWER_FULL);
+    REQUIRE(SDL_JoystickCurrentPowerLevel(joy) == SDL_JOYSTICK_POWER_FULL);
 
     auto base_path =
         std::filesystem::path(

--- a/tests/testJoypads.cpp
+++ b/tests/testJoypads.cpp
@@ -1,4 +1,5 @@
 #include "catch2/catch_all.hpp"
+#include <crc32.hpp>
 #include <filesystem>
 #include <fstream>
 #include <inputtino/input.hpp>
@@ -127,7 +128,7 @@ std::pair<int, std::string> get_system_battery(const std::filesystem::path &powe
   return {capacity, status};
 }
 
-TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL]") {
+TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL],[PS]") {
   // Create the controller
   auto joypad = std::move(*PS5Joypad::create());
 
@@ -151,61 +152,46 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL]") {
   }
   REQUIRE(gc);
 
-  { // Test creating a second device
-    REQUIRE(SDL_NumJoysticks() == 1);
-    auto joypad2 = std::move(*PS5Joypad::create());
-    std::this_thread::sleep_for(50ms);
-
-    auto devices2 = joypad2.get_nodes();
-    REQUIRE_THAT(devices2, SizeIs(5)); // 3 eventXX and 2 jsYY
-    REQUIRE_THAT(devices2, Contains(ContainsSubstring("/dev/input/event")));
-    REQUIRE_THAT(devices2, Contains(ContainsSubstring("/dev/input/js")));
-
-    flush_sdl_events();
-    REQUIRE(SDL_NumJoysticks() == 2);
-    SDL_GameController *gc2 = SDL_GameControllerOpen(1);
-    REQUIRE(SDL_GameControllerGetType(gc2) == SDL_CONTROLLER_TYPE_PS5);
-  }
-
   REQUIRE(SDL_GameControllerGetType(gc) == SDL_CONTROLLER_TYPE_PS5);
   { // Rumble
     // Checking for basic capability
     REQUIRE(SDL_GameControllerHasRumble(gc));
 
-    auto rumble_data = std::make_shared<std::pair<int, int>>();
+    auto rumble_data = std::make_shared<std::pair<int, int>>(0, 0);
     joypad.set_on_rumble([rumble_data](int low_freq, int high_freq) {
-      rumble_data->first = low_freq;
-      rumble_data->second = high_freq;
+      if (rumble_data->first == 0)
+        rumble_data->first = low_freq;
+      if (rumble_data->second == 0)
+        rumble_data->second = high_freq;
     });
 
     // When debugging this, bear in mind that SDL will send max duration here
     // https://github.com/libsdl-org/SDL/blob/da8fc70a83cf6b76d5ea75c39928a7961bd163d3/src/joystick/linux/SDL_sysjoystick.c#L1628
     SDL_GameControllerRumble(gc, 0xFF00, 0xF00F, 100);
     std::this_thread::sleep_for(30ms); // wait for the effect to be picked up
-    REQUIRE(rumble_data->first == 0xFFFF);
-    REQUIRE(rumble_data->second == 0xF0F0);
+    REQUIRE(rumble_data->first == 0x7f7f);
+    REQUIRE(rumble_data->second == 0x7878);
   }
 
   { // LED
-    // Unfortunately LINUX_JoystickSetLED is not implemented in sysjoystick
-    // TODO: force hidapi driver
-    //        REQUIRE(SDL_GameControllerHasLED(gc));
-    //        struct LED {
-    //          int r;
-    //          int g;
-    //          int b;
-    //        };
-    //        auto led_data = std::make_shared<LED>();
-    //        joypad.set_on_led([led_data](int r, int g, int b) {
-    //          led_data->r = r;
-    //          led_data->g = g;
-    //          led_data->b = b;
-    //        });
-    //        SDL_GameControllerSetLED(gc, 50, 100, 150);
-    //        std::this_thread::sleep_for(30ms); // wait for the effect to be picked up
-    //        REQUIRE(led_data->r == 50);
-    //        REQUIRE(led_data->g == 100);
-    //        REQUIRE(led_data->b == 150);
+    REQUIRE(SDL_GameControllerHasLED(gc));
+    struct LED {
+      int r;
+      int g;
+      int b;
+    };
+    auto led_data = std::make_shared<LED>();
+    joypad.set_on_led([led_data](int r, int g, int b) {
+      led_data->r = r;
+      led_data->g = g;
+      led_data->b = b;
+    });
+    SDL_GameControllerSetLED(gc, 50, 100, 150);
+    // TODO: doesn't work
+    // std::this_thread::sleep_for(100ms); // wait for the effect to be picked up
+    // REQUIRE(led_data->r == 50);
+    // REQUIRE(led_data->g == 100);
+    // REQUIRE(led_data->b == 150);
   }
 
   test_buttons(gc, joypad);
@@ -359,9 +345,10 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL]") {
   }
 
   { // Test touchpad
-    // TODO: sysjoystick is lacking implementation, force hidapi
-    // REQUIRE(SDL_GameControllerGetNumTouchpads(gc) == 1);
+    REQUIRE(SDL_GameControllerGetNumTouchpads(gc) == 1);
+    REQUIRE(SDL_GameControllerGetNumTouchpadFingers(gc, 0) == 2);
 
+    // TODO: test these values with SDL
     joypad.place_finger(0, 1920, 1080);
     joypad.place_finger(1, 1920, 1080);
     joypad.release_finger(0);
@@ -369,10 +356,9 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL]") {
   }
 
   { // Test battery
-    // SDL doesn't seem to pick it up..
-    //    auto joy = SDL_GameControllerGetJoystick(gc);
-    //    auto level = SDL_JoystickCurrentPowerLevel(joy);
-    //    REQUIRE(level == SDL_JOYSTICK_POWER_MEDIUM);
+    auto joy = SDL_GameControllerGetJoystick(gc);
+    auto level = SDL_JoystickCurrentPowerLevel(joy);
+    REQUIRE(level == SDL_JOYSTICK_POWER_FULL);
 
     auto base_path =
         std::filesystem::path(
@@ -416,6 +402,23 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL]") {
       REQUIRE(capacity == 100);
       REQUIRE(status == "Full");
     }
+  }
+
+  { // Test creating a second device
+    REQUIRE(SDL_NumJoysticks() == 1);
+    auto joypad2 = std::move(*PS5Joypad::create());
+    std::this_thread::sleep_for(50ms);
+
+    auto devices2 = joypad2.get_nodes();
+    REQUIRE_THAT(devices2, SizeIs(5)); // 3 eventXX and 2 jsYY
+    REQUIRE_THAT(devices2, Contains(ContainsSubstring("/dev/input/event")));
+    REQUIRE_THAT(devices2, Contains(ContainsSubstring("/dev/input/js")));
+
+    flush_sdl_events();
+    REQUIRE(SDL_NumJoysticks() == 2);
+    SDL_GameController *gc2 = SDL_GameControllerOpen(1);
+    REQUIRE(SDL_GameControllerGetType(gc2) == SDL_CONTROLLER_TYPE_PS5);
+    SDL_GameControllerClose(gc2);
   }
 
   // Adaptive triggers aren't supported by SDL
@@ -570,4 +573,15 @@ TEST_CASE_METHOD(SDLTestsFixture, "Nintendo Joypad", "[SDL]") {
   }
 
   SDL_GameControllerClose(gc);
+}
+
+TEST_CASE("Bluetooth CRC32", "[PS]") {
+  std::string buffer = "123456789";
+  auto crc = CRC32(reinterpret_cast<unsigned char *>(buffer.data()), buffer.length());
+  REQUIRE(crc == 0xcbf43926);
+
+  unsigned char PS_INPUT_CRC32_SEED = 0xA1;
+  auto crc2 = CRC32(&PS_INPUT_CRC32_SEED, 1, 0xFFFFFFFF);
+  crc2 = CRC32(reinterpret_cast<unsigned char *>(buffer.data()), buffer.length(), crc2);
+  REQUIRE(crc2 == 0x9498b398);
 }


### PR DESCRIPTION
WIP,

fixes: https://github.com/games-on-whales/inputtino/issues/16
fixes: https://github.com/LizardByte/Sunshine/issues/3468

TODO:
- [x] Remove `zlib` dependency, just need a good embeddable CRC32 implementation
- [x] Fix LED
- [x] Double check in games
- [x] Write the rationale behind both implementations

[EDIT]
blog posts are up:
- [When uinput Isn’t Enough: Virtualizing a DualSense controller](https://abeltra.me/blog/inputtino-uhid-1/)
- [Creating a Virtual DualSense Controller via UHID](https://abeltra.me/blog/inputtino-uhid-2/)
- [Beyond USB: Improving Virtual Controller Support in Linux Games](https://abeltra.me/blog/inputtino-uhid-3/)