### PR TITLE
Ignore tag in DualSense reports.

### DIFF
--- a/src/uhid/include/uhid/ps5.hpp
+++ b/src/uhid/include/uhid/ps5.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <crc32.hpp>
 #include <linux/uhid.h>
 #include <vector>
-#include <crc32.hpp>
 
 namespace uhid {
 
@@ -29,7 +29,7 @@ static constexpr float SDL_STANDARD_GRAVITY = 9.80665f;
  * https://github.com/torvalds/linux/blob/305230142ae0637213bf6e04f6d9f10bbcb74af8/drivers/hid/hid-playstation.c#L70-L72
  */
 static constexpr unsigned char PS_INPUT_CRC32_SEED = 0xA1;
-static constexpr auto PS_INPUT_CRC32= CRC32(&PS_INPUT_CRC32_SEED, 1);
+static constexpr auto PS_INPUT_CRC32 = CRC32(&PS_INPUT_CRC32_SEED, 1);
 static constexpr unsigned char PS_OUTPUT_CRC32_SEED = 0xA2;
 static constexpr auto PS_OUTPUT_CRC32 = CRC32(&PS_OUTPUT_CRC32_SEED, 1);
 static constexpr unsigned char PS_FEATURE_CRC32_SEED = 0xA3;
@@ -528,7 +528,14 @@ static constexpr uint8_t DS_OUTPUT_REPORT_BT = 0x31;
 
 struct dualsense_output_report_bt {
   uint8_t report_id; /* 0x31 */
-  uint8_t seq_tag;
+
+  /* Following has been taken from https://controllers.fandom.com/wiki/Sony_DualSense#Output_Reports */
+  uint8_t UNK1 : 1;      // -+
+  uint8_t EnableHID : 1; //  | - these 3 bits seem to act as an enum
+  uint8_t UNK2 : 1;      // -+
+  uint8_t UNK3 : 1;
+  uint8_t SeqNo : 4; // increment for every write
+
   struct dualsense_output_report_common common;
   uint8_t reserved[24];
   __le32 crc32;

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -135,7 +135,14 @@ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, 
       auto report_usb = (uhid::dualsense_output_report_usb *)ev.u.output.data;
       report = report_usb->common;
     } else {
-      auto report_bt = (uhid::dualsense_output_report_bt *)ev.u.output.data;
+      // In everything *except* SDL, data[3] is a tag.
+      // SDL always seems to send 0x02 as seq_tag value, so we'll use that to detect it.
+      uhid::dualsense_output_report_bt *report_bt;
+      if (ev.u.output.data[1] == 0x02) {
+        report_bt = (uhid::dualsense_output_report_bt *)ev.u.output.data;
+      } else {
+        report_bt = (uhid::dualsense_output_report_bt *)&ev.u.output.data[1];
+      }
       report = report_bt->common;
     }
 

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -135,13 +135,17 @@ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, 
       auto report_usb = (uhid::dualsense_output_report_usb *)ev.u.output.data;
       report = report_usb->common;
     } else {
-      // In everything *except* SDL, data[3] is a tag.
-      // SDL always seems to send 0x02 as seq_tag value, so we'll use that to detect it.
-      uhid::dualsense_output_report_bt *report_bt;
-      if (ev.u.output.data[1] == 0x02) {
-        report_bt = (uhid::dualsense_output_report_bt *)ev.u.output.data;
-      } else {
-        report_bt = (uhid::dualsense_output_report_bt *)&ev.u.output.data[1];
+      uhid::dualsense_output_report_bt *report_bt = (uhid::dualsense_output_report_bt *)ev.u.output.data;
+      /*
+       * SDL2 sets the EnableHID flag and will send the output report straight after
+       * https://github.com/libsdl-org/SDL/blob/c8c4c9772758de2ae466d27f13eb3ed4233e3f32/src/joystick/hidapi/SDL_hidapi_ps5.c#L788-L789
+       *
+       * The Linux kernel instead, sets this as 0, properly set the SeqNo and adds a hardcoded `tag` field before the
+       * actual output report
+       * https://github.com/torvalds/linux/blob/305230142ae0637213bf6e04f6d9f10bbcb74af8/drivers/hid/hid-playstation.c#L1184-L1192
+       */
+      if (report_bt->EnableHID == 0) {
+        report_bt = (uhid::dualsense_output_report_bt *)&ev.u.output.data[1]; // Skip the tag field
       }
       report = report_bt->common;
     }
@@ -270,13 +274,10 @@ template <typename T> std::string to_hex(T i) {
 
 std::string PS5Joypad::get_mac_address() const {
   std::stringstream stream;
-  stream << std::hex << std::setfill('0')
-         << std::setw(2) << (unsigned int)_state->mac_address[0] << ":"
-         << std::setw(2) << (unsigned int)_state->mac_address[1] << ":"
-         << std::setw(2) << (unsigned int)_state->mac_address[2] << ":"
-         << std::setw(2) << (unsigned int)_state->mac_address[3] << ":"
-         << std::setw(2) << (unsigned int)_state->mac_address[4] << ":"
-         << std::setw(2) << (unsigned int)_state->mac_address[5];
+  stream << std::hex << std::setfill('0') << std::setw(2) << (unsigned int)_state->mac_address[0] << ":" << std::setw(2)
+         << (unsigned int)_state->mac_address[1] << ":" << std::setw(2) << (unsigned int)_state->mac_address[2] << ":"
+         << std::setw(2) << (unsigned int)_state->mac_address[3] << ":" << std::setw(2)
+         << (unsigned int)_state->mac_address[4] << ":" << std::setw(2) << (unsigned int)_state->mac_address[5];
   return stream.str();
 }
 


### PR DESCRIPTION
Some applications seem to send a tag before the actual report, except for SDL. This PR adds a check to ignore the tag if it is sent.