### PR TITLE
Fix DualSense MAC address

### DIFF
--- a/include/inputtino/input.hpp
+++ b/include/inputtino/input.hpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <random>
 #include <string>
 #include <thread>
 #include <vector>
@@ -453,6 +454,13 @@ protected:
 
 private:
   std::thread _send_input_thread;
-  PS5Joypad(uint16_t vendor_id);
+
+  static std::array<unsigned char, 6> generate_mac_address() {
+    auto rand = std::bind(std::uniform_int_distribution<unsigned char>{0, 0xFF},
+                          std::default_random_engine{std::random_device()()});
+    return {rand(), rand(), rand(), rand(), rand(), rand()};
+  };
+
+  PS5Joypad(uint16_t vendor_id, std::array<unsigned char, 6> mac_address = generate_mac_address());
 };
 } // namespace inputtino

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -216,16 +216,9 @@ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, 
   }
 }
 
-void generate_mac_address(PS5JoypadState *state) {
-  auto rand = std::bind(std::uniform_int_distribution<unsigned char>{0, 0xFF},
-                        std::default_random_engine{std::random_device()()});
-  for (int i = 0; i < 6; i++) {
-    state->mac_address[i] = rand();
-  }
-}
-
-PS5Joypad::PS5Joypad(uint16_t vendor_id) : _state(std::make_shared<PS5JoypadState>()) {
-  generate_mac_address(this->_state.get());
+PS5Joypad::PS5Joypad(uint16_t vendor_id, std::array<unsigned char, 6> mac_address)
+    : _state(std::make_shared<PS5JoypadState>()) {
+  std::copy(mac_address.begin(), mac_address.end(), this->_state->mac_address);
   this->_state->vendor_id = vendor_id;
   // Set touchpad as not pressed
   this->_state->current_state.points[0].contact = 1;
@@ -265,10 +258,24 @@ Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device) {
     def.report_description = {&uhid::ps5_rdesc[0], &uhid::ps5_rdesc[0] + sizeof(uhid::ps5_rdesc)};
   }
 
-  auto joypad = PS5Joypad(device.vendor_id);
+  std::array<unsigned char, 6> mac_address = {};
+  if (def.uniq.empty()) {
+    mac_address = generate_mac_address();
+  } else {
+    // Assuming we have in input a MAC address in the format of xx:xx:xx:xx:xx:xx
+    std::stringstream ss(def.uniq);
+    for (int i = 0; i < 6; ++i) {
+      unsigned int value;
+      ss >> std::hex >> value;
+      mac_address[i] = static_cast<unsigned char>(value);
+      if (i < 5)
+        ss.ignore(1, ':');
+    }
+  }
+  auto joypad = PS5Joypad(device.vendor_id, mac_address);
 
   if (def.phys.empty()) {
-    def.phys = joypad.get_mac_address();
+    def.phys = "INPUTTINO_BT_LINK";
   }
   if (def.uniq.empty()) {
     def.uniq = joypad.get_mac_address();

--- a/src/uinput/joypad_ps.cpp
+++ b/src/uinput/joypad_ps.cpp
@@ -79,7 +79,8 @@ Result<libevdev_uinput_ptr> create_ps_controller(const DeviceDefinition &device)
   return libevdev_uinput_ptr{uidev, ::libevdev_uinput_destroy};
 }
 
-PS5Joypad::PS5Joypad(uint16_t vendor_id) : _state(std::make_shared<PS5JoypadState>()) {}
+PS5Joypad::PS5Joypad(uint16_t vendor_id, std::array<unsigned char, 6> mac_address) : _state(std::make_shared<PS5JoypadState>()) {
+}
 
 PS5Joypad::~PS5Joypad() {
   if (_state) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ if (UNIX AND NOT APPLE)
                 "testLibinput.cpp")
 
         if (USE_UHID)
+            target_compile_definitions(inputtino_tests PRIVATE USE_UHID)
             list(APPEND SRC_LIST "testUHID.cpp")
         endif ()
     endif ()

--- a/tests/testJoypads.cpp
+++ b/tests/testJoypads.cpp
@@ -255,6 +255,8 @@ TEST_CASE_METHOD(SDLTestsFixture, "Nintendo Joypad", "[SDL]") {
   SDL_GameControllerClose(gc);
 }
 
+#ifndef USE_UHID
+// This test is only valid when using the uinput backend
 TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad (basic)", "[SDL],[PS]") {
   // Create the controller
   auto joypad = std::move(*PS5Joypad::create());
@@ -332,3 +334,4 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad (basic)", "[SDL],[PS]") {
 
   SDL_GameControllerClose(gc);
 }
+#endif // USE_UHID

--- a/tests/testUHID.cpp
+++ b/tests/testUHID.cpp
@@ -57,7 +57,7 @@ public:
     if (SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC | SDL_INIT_GAMECONTROLLER | SDL_INIT_SENSOR | SDL_INIT_EVENTS) <
         0) {
       std::cerr << "SDL could not initialize! SDL_Error: " << SDL_GetError() << std::endl;
-        }
+    }
     SDL_LogSetAllPriority(SDL_LOG_PRIORITY_VERBOSE);
     SDL_GameControllerEventState(SDL_ENABLE);
   }
@@ -66,7 +66,6 @@ public:
     SDL_Quit();
   }
 };
-
 
 #define SDL_TEST_BUTTON(JOYPAD_BTN, SDL_BTN)                                                                           \
   REQUIRE(SDL_GameControllerGetButton(gc, SDL_BTN) == 0);                                                              \
@@ -467,4 +466,17 @@ TEST_CASE("Bluetooth CRC32", "[PS]") {
   auto crc2 = CRC32(&PS_INPUT_CRC32_SEED, 1, 0xFFFFFFFF);
   crc2 = CRC32(reinterpret_cast<unsigned char *>(buffer.data()), buffer.length(), crc2);
   REQUIRE(crc2 == 0x9498b398);
+}
+
+TEST_CASE("Test MAC address", "[PS]") {
+  DeviceDefinition def = {.name = "Wolf DualSense (virtual) pad",
+                          .vendor_id = 0x054C,
+                          .product_id = 0x0CE6,
+                          .version = 0x8111,
+                          .device_uniq = "AA:00:CC:11:EE:22"};
+
+  auto joypad = std::move(*PS5Joypad::create(def));
+
+  std::this_thread::sleep_for(50ms);
+  REQUIRE_THAT(joypad.get_mac_address(), Equals("aa:00:cc:11:ee:22"));
 }


### PR DESCRIPTION
Added proper control over the MAC address generation for DualSense uhid joypads.  
See the discussion at https://github.com/LizardByte/Sunshine/issues/3404 and the PR https://github.com/LizardByte/Sunshine/pull/4158
