### PR TITLE
fix(touchscreen): remove BTN_LEFT from virtual touchscreen

### DIFF
--- a/src/uinput/touchscreen.cpp
+++ b/src/uinput/touchscreen.cpp
@@ -32,7 +32,6 @@ Result<libevdev_uinput_ptr> create_touch_screen(const DeviceDefinition &device) 
   libevdev_set_id_bustype(dev, BUS_USB);
 
   libevdev_enable_event_type(dev, EV_KEY);
-  libevdev_enable_event_code(dev, EV_KEY, BTN_LEFT, nullptr);
   libevdev_enable_event_code(dev, EV_KEY, BTN_TOUCH, nullptr);
 
   libevdev_enable_event_type(dev, EV_ABS);


### PR DESCRIPTION
## Problem

The virtual touchscreen created by `create_touch_screen()` registers `BTN_LEFT` alongside `BTN_TOUCH`. Real touchscreen hardware only reports `BTN_TOUCH` — `BTN_LEFT` is a mouse button.

This causes GNOME/Mutter on Wayland to misclassify the device as a pointer, which breaks touchscreen-to-display mapping (dconf `output` setting is ignored).

## Root cause chain

1. **udev `input_id`** ([systemd source](https://github.com/systemd/systemd/blob/v257/src/udev/udev-builtin-input_id.c#L244)): `BTN_LEFT` (= `BTN_MOUSE`) + `ABS_X/Y` → `is_abs_mouse = true`. This check runs *before* the `is_touchscreen` check, so the device gets **both** `ID_INPUT_MOUSE=1` and `ID_INPUT_TOUCHSCREEN=1`.

2. **libinput**: dual udev tags → device gets both `pointer` and `touch` capabilities.

3. **Mutter `determine_device_type()`** ([mutter source](https://gitlab.gnome.org/GNOME/mutter/-/blob/main/src/backends/native/meta-input-device-native.c)): checks `LIBINPUT_DEVICE_CAP_POINTER` **before** `LIBINPUT_DEVICE_CAP_TOUCH` → device is classified as `CLUTTER_POINTER_DEVICE`.

4. **Mutter `meta-input-mapper.c`**: `get_device_settings()` only reads dconf touchscreen-to-display mapping for `CLUTTER_TOUCHSCREEN_DEVICE` — pointer devices get no mapping → touch events go to the wrong display.

## Fix

Remove `BTN_LEFT` from `create_touch_screen()`. It was never emitted anyway — `place_finger()` and `release_finger()` only write `ABS_MT_*`, `ABS_PRESSURE`, and `BTN_TOUCH` events. Likely a leftover from the mouse device template.

## Verified

Tested with Sunshine + Moonlight (PR #1364 native multitouch) streaming to an Android tablet as a third display on GNOME 49 / Wayland. Without `BTN_LEFT`:
- udev: only `ID_INPUT_TOUCHSCREEN=1`
- libinput: only `touch` capability
- Mutter: `CLUTTER_TOUCHSCREEN_DEVICE` → dconf mapping works
- Touch input correctly mapped to the target display