### PR TITLE
fix(mouse): send clicks and scrolls on active mouse device

### DIFF
--- a/src/uinput/include/inputtino/protected_types.hpp
+++ b/src/uinput/include/inputtino/protected_types.hpp
@@ -61,6 +61,7 @@ struct KeyboardState {
 struct MouseState {
   libevdev_uinput_ptr mouse_rel = nullptr;
   libevdev_uinput_ptr mouse_abs = nullptr;
+  bool absolute = false;
 };
 
 struct TouchScreenState {

--- a/src/uinput/mouse.cpp
+++ b/src/uinput/mouse.cpp
@@ -73,7 +73,7 @@ static Result<libevdev_uinput_ptr> create_mouse_abs(const DeviceDefinition &devi
   libevdev_set_id_version(dev, device.version);
   libevdev_set_id_bustype(dev, BUS_USB);
 
-  libevdev_enable_property(dev, INPUT_PROP_DIRECT);
+  libevdev_enable_property(dev, INPUT_PROP_POINTER);
   libevdev_enable_event_type(dev, EV_KEY);
   libevdev_enable_event_code(dev, EV_KEY, BTN_LEFT, nullptr);
   libevdev_enable_event_code(dev, EV_KEY, BTN_RIGHT, nullptr);

--- a/src/uinput/mouse.cpp
+++ b/src/uinput/mouse.cpp
@@ -76,6 +76,22 @@ static Result<libevdev_uinput_ptr> create_mouse_abs(const DeviceDefinition &devi
   libevdev_enable_property(dev, INPUT_PROP_DIRECT);
   libevdev_enable_event_type(dev, EV_KEY);
   libevdev_enable_event_code(dev, EV_KEY, BTN_LEFT, nullptr);
+  libevdev_enable_event_code(dev, EV_KEY, BTN_RIGHT, nullptr);
+  libevdev_enable_event_code(dev, EV_KEY, BTN_MIDDLE, nullptr);
+  libevdev_enable_event_code(dev, EV_KEY, BTN_SIDE, nullptr);
+  libevdev_enable_event_code(dev, EV_KEY, BTN_EXTRA, nullptr);
+  libevdev_enable_event_code(dev, EV_KEY, BTN_FORWARD, nullptr);
+  libevdev_enable_event_code(dev, EV_KEY, BTN_BACK, nullptr);
+  libevdev_enable_event_code(dev, EV_KEY, BTN_TASK, nullptr);
+
+  libevdev_enable_event_type(dev, EV_REL);
+  libevdev_enable_event_code(dev, EV_REL, REL_WHEEL, nullptr);
+  libevdev_enable_event_code(dev, EV_REL, REL_WHEEL_HI_RES, nullptr);
+  libevdev_enable_event_code(dev, EV_REL, REL_HWHEEL, nullptr);
+  libevdev_enable_event_code(dev, EV_REL, REL_HWHEEL_HI_RES, nullptr);
+
+  libevdev_enable_event_type(dev, EV_MSC);
+  libevdev_enable_event_code(dev, EV_MSC, MSC_SCAN, nullptr);
 
   struct input_absinfo absinfo {
     .value = 0, .minimum = 0, .maximum = 0, .fuzz = 1, .flat = 0, .resolution = 28
@@ -126,6 +142,7 @@ Result<Mouse> Mouse::create(const DeviceDefinition &device) {
 
 void Mouse::move(int delta_x, int delta_y) {
   if (auto mouse = _state->mouse_rel.get()) {
+    _state->absolute = false;
     libevdev_uinput_write_event(mouse, EV_REL, REL_X, delta_x);
     libevdev_uinput_write_event(mouse, EV_REL, REL_Y, delta_y);
     libevdev_uinput_write_event(mouse, EV_SYN, SYN_REPORT, 0);
@@ -137,6 +154,7 @@ void Mouse::move_abs(int x, int y, int screen_width, int screen_height) {
   int scaled_y = (int)std::lround((ABS_MAX_HEIGHT / (double)screen_height) * y);
 
   if (auto mouse = _state->mouse_abs.get()) {
+    _state->absolute = true;
     libevdev_uinput_write_event(mouse, EV_ABS, ABS_X, scaled_x);
     libevdev_uinput_write_event(mouse, EV_ABS, ABS_Y, scaled_y);
     libevdev_uinput_write_event(mouse, EV_SYN, SYN_REPORT, 0);
@@ -158,8 +176,18 @@ static std::pair<int, int> btn_to_uinput(Mouse::MOUSE_BUTTON button) {
   }
 }
 
+static libevdev_uinput *active_mouse_device(MouseState *state) {
+  if (state->absolute) {
+    if (auto mouse = state->mouse_abs.get()) {
+      return mouse;
+    }
+  }
+
+  return state->mouse_rel.get();
+}
+
 void Mouse::press(Mouse::MOUSE_BUTTON button) {
-  if (auto mouse = _state->mouse_rel.get()) {
+  if (auto mouse = active_mouse_device(_state.get())) {
     auto [btn_type, scan_code] = btn_to_uinput(button);
     libevdev_uinput_write_event(mouse, EV_MSC, MSC_SCAN, scan_code);
     libevdev_uinput_write_event(mouse, EV_KEY, btn_type, 1);
@@ -168,7 +196,7 @@ void Mouse::press(Mouse::MOUSE_BUTTON button) {
 }
 
 void Mouse::release(Mouse::MOUSE_BUTTON button) {
-  if (auto mouse = _state->mouse_rel.get()) {
+  if (auto mouse = active_mouse_device(_state.get())) {
     auto [btn_type, scan_code] = btn_to_uinput(button);
     libevdev_uinput_write_event(mouse, EV_MSC, MSC_SCAN, scan_code);
     libevdev_uinput_write_event(mouse, EV_KEY, btn_type, 0);
@@ -179,7 +207,7 @@ void Mouse::release(Mouse::MOUSE_BUTTON button) {
 void Mouse::horizontal_scroll(int high_res_distance) {
   int distance = high_res_distance / 120;
 
-  if (auto mouse = _state->mouse_rel.get()) {
+  if (auto mouse = active_mouse_device(_state.get())) {
     libevdev_uinput_write_event(mouse, EV_REL, REL_HWHEEL, distance);
     libevdev_uinput_write_event(mouse, EV_REL, REL_HWHEEL_HI_RES, high_res_distance);
     libevdev_uinput_write_event(mouse, EV_SYN, SYN_REPORT, 0);
@@ -189,7 +217,7 @@ void Mouse::horizontal_scroll(int high_res_distance) {
 void Mouse::vertical_scroll(int high_res_distance) {
   int distance = high_res_distance / 120;
 
-  if (auto mouse = _state->mouse_rel.get()) {
+  if (auto mouse = active_mouse_device(_state.get())) {
     libevdev_uinput_write_event(mouse, EV_REL, REL_WHEEL, distance);
     libevdev_uinput_write_event(mouse, EV_REL, REL_WHEEL_HI_RES, high_res_distance);
     libevdev_uinput_write_event(mouse, EV_SYN, SYN_REPORT, 0);

--- a/tests/testLibinput.cpp
+++ b/tests/testLibinput.cpp
@@ -166,6 +166,33 @@ TEST_CASE("virtual mouse absolue", "[LIBINPUT]") {
       REQUIRE_THAT(libinput_event_pointer_get_absolute_x_transformed(p_event, TARGET_WIDTH),
                    WithinRel(TARGET_WIDTH, 0.001f));
     }
+
+    {
+        mouse.press(Mouse::RIGHT);
+        event = get_event(li);
+        REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_POINTER_BUTTON);
+        auto p_event = libinput_event_get_pointer_event(event.get());
+        REQUIRE(libinput_event_pointer_get_button(p_event) == BTN_RIGHT);
+        REQUIRE(libinput_event_pointer_get_button_state(p_event) == LIBINPUT_BUTTON_STATE_PRESSED);
+    }
+
+    {
+        mouse.release(Mouse::RIGHT);
+        event = get_event(li);
+        REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_POINTER_BUTTON);
+        auto p_event = libinput_event_get_pointer_event(event.get());
+        REQUIRE(libinput_event_pointer_get_button(p_event) == BTN_RIGHT);
+        REQUIRE(libinput_event_pointer_get_button_state(p_event) == LIBINPUT_BUTTON_STATE_RELEASED);
+    }
+
+    {
+        mouse.vertical_scroll(121);
+        event = get_event(li);
+        REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_POINTER_SCROLL_WHEEL);
+        auto p_event = libinput_event_get_pointer_event(event.get());
+        REQUIRE(libinput_event_pointer_get_scroll_value_v120(p_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL) == -121);
+        event = get_event(li); // skipping LIBINPUT_EVENT_POINTER_AXIS
+    }
 }
 
 TEST_CASE("virtual touch screen", "[LIBINPUT]") {

--- a/tests/testLibinput.cpp
+++ b/tests/testLibinput.cpp
@@ -190,9 +190,41 @@ TEST_CASE("virtual mouse absolue", "[LIBINPUT]") {
         event = get_event(li);
         REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_POINTER_SCROLL_WHEEL);
         auto p_event = libinput_event_get_pointer_event(event.get());
+        // REL_WHEEL positive is up in evdev; libinput reports vertical scroll with the opposite sign.
         REQUIRE(libinput_event_pointer_get_scroll_value_v120(p_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL) == -121);
-        event = get_event(li); // skipping LIBINPUT_EVENT_POINTER_AXIS
+        event = get_event(li);
+        REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_POINTER_AXIS);
     }
+}
+
+TEST_CASE("virtual mouse switches back to relative device", "[LIBINPUT]") {
+    auto mouse = std::move(*Mouse::create());
+    auto rel = create_libinput_context({mouse.get_nodes()[0]});
+    auto abs = create_libinput_context({mouse.get_nodes()[1]});
+
+    auto event = get_event(rel);
+    REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_DEVICE_ADDED);
+    event = get_event(abs);
+    REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_DEVICE_ADDED);
+
+    mouse.move_abs(100, 100, 1920, 1080);
+    event = get_event(abs);
+    REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_POINTER_MOTION_ABSOLUTE);
+
+    mouse.move(100, 100);
+    event = get_event(rel);
+    REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_POINTER_MOTION);
+    auto p_event = libinput_event_get_pointer_event(event.get());
+    REQUIRE(libinput_event_pointer_get_dx_unaccelerated(p_event) == 100);
+    REQUIRE(libinput_event_pointer_get_dy_unaccelerated(p_event) == 100);
+
+    mouse.vertical_scroll(121);
+    event = get_event(rel);
+    REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_POINTER_SCROLL_WHEEL);
+    p_event = libinput_event_get_pointer_event(event.get());
+    REQUIRE(libinput_event_pointer_get_scroll_value_v120(p_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL) == -121);
+    event = get_event(rel);
+    REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_POINTER_AXIS);
 }
 
 TEST_CASE("virtual touch screen", "[LIBINPUT]") {


### PR DESCRIPTION
## Summary
- route mouse buttons and wheel events through the absolute mouse device after absolute motion is used
- advertise button, wheel, hi-res wheel, and MSC_SCAN capabilities on the absolute mouse device
- add libinput coverage for buttons and wheel events on the absolute mouse device

## Context
This fixes unreliable scrolling/clicking in remote desktop mouse mode when clients send absolute pointer motion. In that mode, movement was emitted from the absolute virtual mouse while buttons and scroll were emitted from the relative virtual mouse, so compositors/libinput could treat those events as coming from different pointers.

Refs moonlight-stream/moonlight-qt#1020

## Testing
- git diff --check
- cmake -S . -B build-pr-lib -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=OFF
- cmake --build build-pr-lib -j16
- Manually verified through Sunshine/Moonlight remote desktop mouse mode on Linux