### PR TITLE
feat(joypad): add recreate_device() to rebuild a virtual device in place

### DIFF
--- a/include/inputtino/input.hpp
+++ b/include/inputtino/input.hpp
@@ -317,6 +317,22 @@ public:
   virtual void set_triggers(int16_t left, int16_t right) = 0;
 
   virtual void set_stick(STICK_POSITION stick_type, short x, short y) = 0;
+
+  /**
+   * Tears down and re-creates the underlying virtual device in place, keeping
+   * this object (and its registered callbacks, such as rumble) alive.
+   *
+   * Destroying the old device issues UI_DEV_DESTROY, which invalidates any file
+   * descriptor that another process still holds open against the old
+   * /dev/input node (for example a container that opened it directly). A fresh
+   * device with a new major:minor is created in its place, so input can be
+   * routed to a single consumer again instead of leaking to every process that
+   * ever opened the node.
+   *
+   * The default implementation is a no-op; device types that support being
+   * re-plugged across containers override this.
+   */
+  virtual void recreate_device() {}
 };
 
 class XboxOneJoypad : public Joypad {
@@ -339,6 +355,7 @@ public:
   void set_triggers(int16_t left, int16_t right) override;
   void set_stick(STICK_POSITION stick_type, short x, short y) override;
   void set_on_rumble(const std::function<void(int low_freq, int high_freq)> &callback);
+  void recreate_device() override;
 
 protected:
   typedef struct XboxOneJoypadState XboxOneJoypadState;
@@ -367,6 +384,7 @@ public:
   void set_triggers(int16_t left, int16_t right) override;
   void set_stick(STICK_POSITION stick_type, short x, short y) override;
   void set_on_rumble(const std::function<void(int low_freq, int high_freq)> &callback);
+  void recreate_device() override;
 
 protected:
   typedef struct XboxOneJoypadState SwitchJoypadState;
@@ -383,6 +401,9 @@ public:
              .name = "Wolf DualSense (virtual) pad", .vendor_id = 0x054C, .product_id = 0x0CE6, .version = 0x8111});
   PS5Joypad(PS5Joypad &&j) noexcept : _state(nullptr) {
     std::swap(j._state, _state);
+    // The report pump is joinable (not detached) so recreate_device()/the destructor can wait for it; it must
+    // travel with the state it writes to, otherwise the moved-from object would terminate() on a joinable thread.
+    std::swap(j._send_input_thread, _send_input_thread);
   }
   ~PS5Joypad() override;
 
@@ -396,6 +417,7 @@ public:
   void set_triggers(int16_t left, int16_t right) override;
   void set_stick(STICK_POSITION stick_type, short x, short y) override;
   void set_on_rumble(const std::function<void(int low_freq, int high_freq)> &callback);
+  void recreate_device() override;
 
   static constexpr int touchpad_width = 1920;
   static constexpr int touchpad_height = 1080;

--- a/src/uhid/include/uhid/protected_types.hpp
+++ b/src/uhid/include/uhid/protected_types.hpp
@@ -8,6 +8,12 @@
 namespace inputtino {
 struct PS5JoypadState {
   std::shared_ptr<uhid::Device> dev;
+
+  /**
+   * The uhid definition used to create dev. Kept so recreate_device() can tear the device down and build an
+   * identical one (same MAC/uniq, so get_sys_nodes() still matches) without losing the joypad's other state.
+   */
+  uhid::DeviceDefinition def = {};
   /**
    * This will be the MAC address of the device
    *

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -286,19 +286,59 @@ Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device) {
   if (dev) {
     joypad._state->is_bluetooth = use_bluetooth;
     joypad._state->dev = std::make_shared<uhid::Device>(std::move(*dev));
+    // Stash the (fully resolved) definition so the device can be re-created in place later.
+    joypad._state->def = def;
 
-    // Readers will expect frequent events event if the state hasn't changed
+    // Readers will expect frequent events event if the state hasn't changed.
+    // The thread is kept joinable (see the move constructor) so it can be stopped cleanly before the device it
+    // writes to is destroyed, both on teardown and in recreate_device().
     joypad._send_input_thread = std::thread([state = joypad._state]() {
       while (!state->stop_repeat_thread) {
         send_report(*state);
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
       }
     });
-    joypad._send_input_thread.detach();
 
     return joypad;
   }
   return Error(dev.getErrorMessage());
+}
+
+void PS5Joypad::recreate_device() {
+  if (!_state || !_state->dev) {
+    return;
+  }
+
+  // Stop the report pump first and wait for it to finish: send_report() writes to _state->dev, so it must not be
+  // running while we tear the device down.
+  _state->stop_repeat_thread = true;
+  if (_send_input_thread.joinable()) {
+    _send_input_thread.join();
+  }
+
+  // Destroy the old device (UHID_DESTROY + close). This invalidates any fd another container still holds open
+  // against the old node, so input can no longer leak there. stop_thread() also joins the device's own event
+  // listener before we drop it.
+  _state->dev->stop_thread();
+  _state->dev.reset();
+
+  // Re-create an identical device (same MAC/uniq via the stashed definition) so node matching stays stable, then
+  // re-arm the report pump. The callbacks (rumble/LED/trigger) and current_state live in _state and are preserved.
+  auto dev =
+      uhid::Device::create(_state->def, [state = _state](uhid_event ev, int fd) { on_uhid_event(state, ev, fd); });
+  if (!dev) {
+    fprintf(stderr, "Unable to recreate PS5 joypad device: %s\n", dev.getErrorMessage().c_str());
+    return;
+  }
+  _state->dev = std::make_shared<uhid::Device>(std::move(*dev));
+
+  _state->stop_repeat_thread = false;
+  _send_input_thread = std::thread([state = _state]() {
+    while (!state->stop_repeat_thread) {
+      send_report(*state);
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  });
 }
 
 static int scale_value(int input, int input_start, int input_end, int output_start, int output_end) {

--- a/src/uinput/include/inputtino/protected_types.hpp
+++ b/src/uinput/include/inputtino/protected_types.hpp
@@ -45,7 +45,21 @@ struct BaseJoypadState {
   bool stop_listening_events = false;
   std::thread events_thread;
 
+  /**
+   * Bumped every time the underlying device is (re)created. The rumble listener thread captures the value it was
+   * started with and exits once it changes, so a stale listener bound to a destroyed device stops on its own
+   * when recreate_device() swaps in a replacement.
+   */
+  unsigned long device_generation = 0;
+
   std::optional<std::function<void(int low_freq, int high_freq)>> on_rumble = std::nullopt;
+
+  /**
+   * The definition used to create the underlying uinput device.
+   * Kept so the device can be torn down and re-created in place (see
+   * recreate_device()) without losing the registered callbacks.
+   */
+  DeviceDefinition definition = {};
 };
 
 struct XboxOneJoypadState : BaseJoypadState {};

--- a/src/uinput/joypad_nintendo.cpp
+++ b/src/uinput/joypad_nintendo.cpp
@@ -98,12 +98,39 @@ Result<SwitchJoypad> SwitchJoypad::create(const DeviceDefinition &device) {
 
   SwitchJoypad joypad;
   joypad._state->joy = std::move(*joy_el);
+  joypad._state->definition = device;
 
-  auto event_thread = std::thread(event_listener, joypad._state);
+  auto event_thread = std::thread(event_listener, joypad._state, joypad._state->device_generation);
   joypad._state->events_thread = std::move(event_thread);
   joypad._state->events_thread.detach();
 
   return joypad;
+}
+
+void SwitchJoypad::recreate_device() {
+  if (!_state) {
+    return;
+  }
+
+  // Build the replacement device first; if this fails we keep the existing one
+  // rather than ending up with no device at all.
+  auto new_joy = create_nintendo_controller(_state->definition);
+  if (!new_joy) {
+    std::cerr << "Unable to recreate Nintendo joypad device: " << new_joy.getErrorMessage() << std::endl;
+    return;
+  }
+
+  // Bump the generation so the listener tied to the old device stops on its own.
+  auto generation = ++_state->device_generation;
+
+  // Replacing the managed pointer destroys the previous uinput device (UI_DEV_DESTROY). Any fd still held open
+  // against the old node, e.g. in another container, is invalidated, so input can no longer leak there.
+  _state->joy = std::move(*new_joy);
+
+  // Start a fresh listener for the new device. on_rumble and the rest of the state are preserved, so feedback
+  // keeps working without re-wiring.
+  _state->events_thread = std::thread(event_listener, _state, generation);
+  _state->events_thread.detach();
 }
 
 void SwitchJoypad::set_pressed_buttons(unsigned int newly_pressed) {

--- a/src/uinput/joypad_ps.cpp
+++ b/src/uinput/joypad_ps.cpp
@@ -99,12 +99,39 @@ Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device) {
 
   PS5Joypad joypad(0);
   joypad._state->joy = std::move(*joy_el);
+  joypad._state->definition = device;
 
-  auto event_thread = std::thread(event_listener, joypad._state);
+  auto event_thread = std::thread(event_listener, joypad._state, joypad._state->device_generation);
   joypad._state->events_thread = std::move(event_thread);
   joypad._state->events_thread.detach();
 
   return joypad;
+}
+
+void PS5Joypad::recreate_device() {
+  if (!_state) {
+    return;
+  }
+
+  // Build the replacement device first; if this fails we keep the existing one
+  // rather than ending up with no device at all.
+  auto new_joy = create_ps_controller(_state->definition);
+  if (!new_joy) {
+    std::cerr << "Unable to recreate PS joypad device: " << new_joy.getErrorMessage() << std::endl;
+    return;
+  }
+
+  // Bump the generation so the listener tied to the old device stops on its own.
+  auto generation = ++_state->device_generation;
+
+  // Replacing the managed pointer destroys the previous uinput device (UI_DEV_DESTROY). Any fd still held open
+  // against the old node, e.g. in another container, is invalidated, so input can no longer leak there.
+  _state->joy = std::move(*new_joy);
+
+  // Start a fresh listener for the new device. on_rumble and the rest of the state are preserved, so feedback
+  // keeps working without re-wiring.
+  _state->events_thread = std::thread(event_listener, _state, generation);
+  _state->events_thread.detach();
 }
 
 void PS5Joypad::set_pressed_buttons(unsigned int newly_pressed) {

--- a/src/uinput/joypad_utils.hpp
+++ b/src/uinput/joypad_utils.hpp
@@ -147,7 +147,7 @@ static ActiveRumbleEffect create_rumble_effect(const ff_effect &effect) {
  *      where the value is the request ID
  *   You can test the virtual devices that we create by simply using the utility `fftest`
  */
-static void event_listener(const std::shared_ptr<BaseJoypadState> &state) {
+static void event_listener(const std::shared_ptr<BaseJoypadState> &state, unsigned long generation) {
   std::this_thread::sleep_for(100ms); // We have to sleep in order to be able to read from the newly created device
 
   auto uinput_fd = libevdev_uinput_get_fd(state->joy.get());
@@ -170,7 +170,10 @@ static void event_listener(const std::shared_ptr<BaseJoypadState> &state) {
   std::array<pollfd, 1> pfds = {pollfd{.fd = uinput_fd, .events = POLLIN}};
   int poll_rs = 0;
 
-  while (!state->stop_listening_events) {
+  // Keep listening until either the joypad is being torn down (stop_listening_events) or the device we were
+  // started for has been swapped out from under us by recreate_device() (generation bumped); in the latter case
+  // our fd is now invalid and a new listener is already running against the replacement device.
+  while (!state->stop_listening_events && state->device_generation == generation) {
     poll_rs = poll(pfds.data(), pfds.size(), RUMBLE_POLL_TIMEOUT);
     if (poll_rs < 0) {
       std::cerr << "Failed polling uinput fd; ret=" << strerror(errno);

--- a/src/uinput/joypad_xbox.cpp
+++ b/src/uinput/joypad_xbox.cpp
@@ -95,11 +95,38 @@ Result<XboxOneJoypad> XboxOneJoypad::create(const DeviceDefinition &device) {
 
   XboxOneJoypad joypad;
   joypad._state->joy = std::move(*joy_el);
+  joypad._state->definition = device;
 
-  auto event_thread = std::thread(event_listener, joypad._state);
+  auto event_thread = std::thread(event_listener, joypad._state, joypad._state->device_generation);
   joypad._state->events_thread = std::move(event_thread);
   joypad._state->events_thread.detach();
   return joypad;
+}
+
+void XboxOneJoypad::recreate_device() {
+  if (!_state) {
+    return;
+  }
+
+  // Build the replacement device first; if this fails we keep the existing one
+  // rather than ending up with no device at all.
+  auto new_joy = create_xbox_controller(_state->definition);
+  if (!new_joy) {
+    std::cerr << "Unable to recreate Xbox joypad device: " << new_joy.getErrorMessage() << std::endl;
+    return;
+  }
+
+  // Bump the generation so the listener tied to the old device stops on its own.
+  auto generation = ++_state->device_generation;
+
+  // Replacing the managed pointer destroys the previous uinput device (UI_DEV_DESTROY). Any fd still held open
+  // against the old node, e.g. in another container, is invalidated, so input can no longer leak there.
+  _state->joy = std::move(*new_joy);
+
+  // Start a fresh listener for the new device. on_rumble and the rest of the state are preserved, so feedback
+  // keeps working without re-wiring.
+  _state->events_thread = std::thread(event_listener, _state, generation);
+  _state->events_thread.detach();
 }
 
 void XboxOneJoypad::set_pressed_buttons(unsigned int newly_pressed) {


### PR DESCRIPTION
## Problem
We share one virtual joypad between containers by mknod-ing the node and faking udev events, then rm-ing it on unplug. Removing the node doesn't close an fd another process already has open, so anything that opened the device keeps reading it. There's no way to evict that reader from outside short of destroying the device.

## Change
Add `Joypad::recreate_device()`: tear the underlying device down (UI_DEV_DESTROY / UHID_DESTROY, which invalidates the stale fd) and build a fresh one in its place, keeping the object and its callbacks (rumble, LED, triggers) intact.

- uinput (Xbox/Switch/PS) stash their `DeviceDefinition` and bump a per-state generation so the detached rumble listener on the old device exits on its own.
- uhid DualSense keeps its report pump joinable (the move ctor now carries it) so it stops before the device it writes to is destroyed, then rebuilds from the stashed uhid definition with the same MAC so `get_sys_nodes()` matching stays stable. This also closes a latent race in the old destructor, which could reset the device while a detached pump was still writing.

Base class default is a no-op.

Used by Wolf to stop gamepad input leaking across lobby switches (games-on-whales/wolf#435).