### PR TITLE
[5/5] Joy-Con (L/R) support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,27 +108,38 @@ set(PUBLIC_HEADERS
         include/inputtino/input.h)
 
 if (UNIX AND NOT APPLE)
+    # The basic uinput joypads (XboxOneJoypad, PS5JoypadUinput, SwitchJoypad)
+    # are always built: they need only uinput and act as the universal fallback
+    # picked by create_joypad() when /dev/uhid is unavailable.
     list(APPEND SRC_LIST
             "src/mac.cpp"
-            "src/uinput/joypad_nintendo.cpp"
+            "src/host_capability.cpp"
             "src/uinput/joypad_xbox.cpp"
+            "src/uinput/joypad_ps.cpp"
+            "src/uinput/joypad_nintendo.cpp"
             "src/uinput/keyboard.cpp"
             "src/uinput/mouse.cpp"
             "src/uinput/pentablet.cpp"
             "src/uinput/touchscreen.cpp"
             "src/uinput/trackpad.cpp")
 
+    # USE_UHID additionally builds the rich uhid joypads (PS5Joypad, SwitchJoypad).
+    # It defaults ON; both backends then coexist and the choice is made at runtime
+    # by create_joypad(). USE_UHID=OFF drops the uhid sources for size-constrained
+    # builds, in which case create_joypad() always returns the uinput backend.
     if (USE_UHID)
-        message("Using uhid implementation for DualSense controller")
+        message("Building uhid joypads (PS5Joypad / SwitchJoypad) alongside the uinput fallbacks")
         list(APPEND SRC_LIST "src/uhid/joypad_ps5.cpp" "src/uhid/uhid.cpp")
         target_include_directories(libinputtino PUBLIC "src/uhid/include/")
+        target_compile_definitions(libinputtino PRIVATE INPUTTINO_USE_UHID)
     else ()
-        message("Using uinput implementation for DualSense controller")
-        list(APPEND SRC_LIST "src/uinput/joypad_ps.cpp")
+        message("USE_UHID=OFF: building uinput joypads only; create_joypad() will not offer uhid backends")
     endif ()
 
     target_sources(libinputtino PRIVATE ${SRC_LIST})
     target_include_directories(libinputtino PUBLIC "src/uinput/include")
+    # Internal helpers shared by the uinput and uhid joypad backends (udev_helpers.hpp)
+    target_include_directories(libinputtino PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
 endif ()
 
 if (BUILD_C_BINDINGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ set(PUBLIC_HEADERS
         include/inputtino/input.h)
 
 if (UNIX AND NOT APPLE)
-    # The basic uinput joypads (XboxOneJoypad, PS5JoypadUinput, SwitchJoypad)
+    # The basic uinput joypads (XboxOneJoypad, PS5JoypadUinput, SwitchJoypadUinput)
     # are always built: they need only uinput and act as the universal fallback
     # picked by create_joypad() when /dev/uhid is unavailable.
     list(APPEND SRC_LIST
@@ -130,6 +130,7 @@ if (UNIX AND NOT APPLE)
     if (USE_UHID)
         message("Building uhid joypads (PS5Joypad / SwitchJoypad) alongside the uinput fallbacks")
         list(APPEND SRC_LIST "src/uhid/joypad_ps5.cpp" "src/uhid/uhid.cpp")
+        list(APPEND SRC_LIST "src/uhid/joypad_switch.cpp")
         target_include_directories(libinputtino PUBLIC "src/uhid/include/")
         target_compile_definitions(libinputtino PRIVATE INPUTTINO_USE_UHID)
     else ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ if (UNIX AND NOT APPLE)
 
     if (USE_UHID)
         message("Using uhid implementation for DualSense controller")
-        list(APPEND SRC_LIST "src/uhid/joypad_ps5.cpp")
+        list(APPEND SRC_LIST "src/uhid/joypad_ps5.cpp" "src/uhid/uhid.cpp")
         target_include_directories(libinputtino PUBLIC "src/uhid/include/")
     else ()
         message("Using uinput implementation for DualSense controller")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ set(PUBLIC_HEADERS
 
 if (UNIX AND NOT APPLE)
     list(APPEND SRC_LIST
+            "src/mac.cpp"
             "src/uinput/joypad_nintendo.cpp"
             "src/uinput/joypad_xbox.cpp"
             "src/uinput/keyboard.cpp"

--- a/include/inputtino/input.hpp
+++ b/include/inputtino/input.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <array>
 #include <cstdint>
 #include <functional>
+#include <inputtino/mac.hpp>
 #include <inputtino/result.hpp>
 #include <map>
 #include <memory>
 #include <optional>
-#include <random>
 #include <string>
 #include <thread>
 #include <vector>
@@ -456,6 +455,6 @@ protected:
 private:
   std::thread _send_input_thread;
 
-  PS5Joypad(uint16_t vendor_id, std::array<unsigned char, 6> mac);
+  PS5Joypad(uint16_t vendor_id, const Mac &mac);
 };
 } // namespace inputtino

--- a/include/inputtino/input.hpp
+++ b/include/inputtino/input.hpp
@@ -25,7 +25,7 @@ namespace inputtino {
  * SwitchJoypad expose. It requires `/dev/uhid` (root, plus the
  * udev rule in `src/uhid/README.adoc`); on locked-down hosts it
  * doesn't exist and the fallback uinput implementations
- * (PS5JoypadUinput, SwitchJoypad, XboxOneJoypad) should be used
+ * (PS5JoypadUinput, SwitchJoypadUinput, XboxOneJoypad) should be used
  * instead.
  *
  * Probes by `open("/dev/uhid", O_RDWR)` once and caches the result
@@ -363,7 +363,7 @@ public:
    *
    * Picks the backend at runtime: when `prefer_uhid` is true and the host can
    * create uhid devices, returns the rich uhid pad (`PS5Joypad` / `SwitchJoypad`);
-   * otherwise the basic uinput pad (`PS5JoypadUinput` / `SwitchJoypad`).
+   * otherwise the basic uinput pad (`PS5JoypadUinput` / `SwitchJoypadUinput`).
    * `XBOX` is uinput-only. The pad is owned through this `Joypad` base, so any
    * capability is reachable via the base interface — unsupported ones are safe
    * no-ops; gate motion on `supports_motion()`.
@@ -495,6 +495,58 @@ private:
   XboxOneJoypad();
 };
 
+class SwitchJoypad : public Joypad {
+public:
+  static Result<SwitchJoypad> create(const DeviceDefinition &device = {
+                                         .name = "Wolf Nintendo (virtual) pad",
+                                         // https://github.com/torvalds/linux/blob/master/drivers/hid/hid-ids.h#L981
+                                         .vendor_id = 0x057e,
+                                         .product_id = 0x2009,
+                                         .version = 0x8111});
+  SwitchJoypad(SwitchJoypad &&j) noexcept : _state(nullptr) {
+    std::swap(j._state, _state);
+    std::swap(j._send_input_thread, _send_input_thread);
+  }
+  ~SwitchJoypad() override;
+
+  std::vector<std::string> get_nodes() const override;
+  std::vector<UdevEvent> get_udev_events() const override;
+  std::vector<UdevHwDbEntry> get_udev_hw_db_entries() const override;
+
+  std::string get_mac_address() const;
+
+  std::vector<std::string> get_sys_nodes() const;
+
+  void set_pressed_buttons(unsigned int newly_pressed) override;
+  void set_triggers(int16_t left, int16_t right) override;
+  void set_stick(STICK_POSITION stick_type, short x, short y) override;
+  bool supports_motion() const override {
+    return true;
+  }
+  /**
+   * Forward a gyroscope sample, in deg/s (SDL / Moonlight convention). Unlike
+   * PS5's rad/s report no unit fix is needed — only the SDL->hid-nintendo frame
+   * remap. Axes follow the SDL convention.
+   */
+  void set_gyro(float x, float y, float z) override;
+
+  /**
+   * Forward an accelerometer sample, in m/s^2 (inclusive of gravity); SDL axis
+   * convention, with the SDL->hid-nintendo frame remap.
+   */
+  void set_accel(float x, float y, float z) override;
+  void set_on_rumble(const std::function<void(int low_freq, int high_freq)> &callback) override;
+
+protected:
+  typedef struct SwitchJoypadState SwitchJoypadState;
+  std::shared_ptr<SwitchJoypadState> _state;
+
+private:
+  std::thread _send_input_thread;
+
+  SwitchJoypad(const Mac &mac);
+};
+
 class PS5Joypad : public Joypad {
 public:
   static Result<PS5Joypad>
@@ -612,15 +664,15 @@ private:
  * Joypad API, matching SwitchJoypad), sticks and rumble. No motion (inherits
  * the base no-op + supports_motion() == false). uinput-only fallback.
  */
-class SwitchJoypad : public Joypad {
+class SwitchJoypadUinput : public Joypad {
 public:
-  static Result<SwitchJoypad>
+  static Result<SwitchJoypadUinput>
   create(const DeviceDefinition &device = {
              .name = "Wolf Nintendo (virtual) pad", .vendor_id = 0x057e, .product_id = 0x2009, .version = 0x8111});
-  SwitchJoypad(SwitchJoypad &&j) noexcept : _state(nullptr) {
+  SwitchJoypadUinput(SwitchJoypadUinput &&j) noexcept : _state(nullptr) {
     std::swap(j._state, _state);
   }
-  ~SwitchJoypad() override;
+  ~SwitchJoypadUinput() override;
 
   std::vector<std::string> get_nodes() const override;
   std::vector<UdevEvent> get_udev_events() const override;
@@ -632,11 +684,11 @@ public:
   void set_on_rumble(const std::function<void(int low_freq, int high_freq)> &callback) override;
 
 protected:
-  typedef struct SwitchJoypadState SwitchJoypadState;
-  std::shared_ptr<SwitchJoypadState> _state;
+  typedef struct SwitchJoypadUinputState SwitchJoypadUinputState;
+  std::shared_ptr<SwitchJoypadUinputState> _state;
 
 private:
-  SwitchJoypad();
+  SwitchJoypadUinput();
 };
 
 } // namespace inputtino

--- a/include/inputtino/input.hpp
+++ b/include/inputtino/input.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <inputtino/result.hpp>
@@ -455,12 +456,6 @@ protected:
 private:
   std::thread _send_input_thread;
 
-  static std::array<unsigned char, 6> generate_mac_address() {
-    auto rand = std::bind(std::uniform_int_distribution<unsigned char>{0, 0xFF},
-                          std::default_random_engine{std::random_device()()});
-    return {rand(), rand(), rand(), rand(), rand(), rand()};
-  };
-
-  PS5Joypad(uint16_t vendor_id, std::array<unsigned char, 6> mac_address = generate_mac_address());
+  PS5Joypad(uint16_t vendor_id, std::array<unsigned char, 6> mac);
 };
 } // namespace inputtino

--- a/include/inputtino/input.hpp
+++ b/include/inputtino/input.hpp
@@ -321,7 +321,9 @@ public:
   enum class TYPE {
     XBOX,
     PS,
-    NINTENDO
+    NINTENDO,
+    JOYCON_LEFT,
+    JOYCON_RIGHT
   };
 
   enum CONTROLLER_BTN : unsigned int {
@@ -514,6 +516,7 @@ public:
   std::vector<UdevHwDbEntry> get_udev_hw_db_entries() const override;
 
   std::string get_mac_address() const;
+  uint16_t get_product_id() const;
 
   std::vector<std::string> get_sys_nodes() const;
 

--- a/include/inputtino/input.hpp
+++ b/include/inputtino/input.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <inputtino/mac.hpp>
@@ -9,13 +10,57 @@
 #include <optional>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace inputtino {
 
+/**
+ * Returns true when this host can create UHID virtual devices.
+ *
+ * UHID is the kernel interface that lets inputtino emit a "real"
+ * HID device (PS5 DualSense, Switch Pro, ...) the host can read
+ * via the usual hidraw / evdev path — including the rich
+ * accelerometer/gyro/touchpad subdevices that PS5Joypad and
+ * SwitchJoypad expose. It requires `/dev/uhid` (root, plus the
+ * udev rule in `src/uhid/README.adoc`); on locked-down hosts it
+ * doesn't exist and the fallback uinput implementations
+ * (PS5JoypadUinput, SwitchJoypad, XboxOneJoypad) should be used
+ * instead.
+ *
+ * Probes by `open("/dev/uhid", O_RDWR)` once and caches the result
+ * for the process lifetime — the device node doesn't appear or
+ * disappear mid-run on any sane host.
+ */
+bool is_uhid_supported();
+
 class VirtualDevice {
 public:
   virtual std::vector<std::string> get_nodes() const = 0;
+
+  /**
+   * udev self-description.
+   *
+   * A device created via uinput/uhid shows up as a bare node under /dev/input
+   * with no backing udev database. Consumers that run apps inside a mount/PID
+   * namespace (e.g. a container) need to synthesise the udev events and hwdb
+   * entries so libudev/SDL inside the namespace recognise the device as real,
+   * fully-described hardware. Since this library created the device — and thus
+   * knows its nodes, vendor/product ids and (for uhid) the HID identity — it is
+   * the natural place to describe it.
+   *
+   * Both default to empty so devices/platforms that don't need this are
+   * unaffected.
+   */
+  using UdevEvent = std::map<std::string, std::string>;
+  using UdevHwDbEntry = std::pair<std::string /* filename */, std::vector<std::string> /* rows */>;
+  virtual std::vector<UdevEvent> get_udev_events() const {
+    return {};
+  }
+  virtual std::vector<UdevHwDbEntry> get_udev_hw_db_entries() const {
+    return {};
+  }
+
   virtual ~VirtualDevice() = default;
 };
 
@@ -269,6 +314,16 @@ private:
  */
 class Joypad : public VirtualDevice {
 public:
+  /**
+   * Which kind of pad create() should build; the concrete uhid/uinput backend is
+   * then chosen at runtime.
+   */
+  enum class TYPE {
+    XBOX,
+    PS,
+    NINTENDO
+  };
+
   enum CONTROLLER_BTN : unsigned int {
     DPAD_UP = 0x0001,
     DPAD_DOWN = 0x0002,
@@ -304,6 +359,32 @@ public:
   };
 
   /**
+   * Runtime joypad factory.
+   *
+   * Picks the backend at runtime: when `prefer_uhid` is true and the host can
+   * create uhid devices, returns the rich uhid pad (`PS5Joypad` / `SwitchJoypad`);
+   * otherwise the basic uinput pad (`PS5JoypadUinput` / `SwitchJoypad`).
+   * `XBOX` is uinput-only. The pad is owned through this `Joypad` base, so any
+   * capability is reachable via the base interface — unsupported ones are safe
+   * no-ops; gate motion on `supports_motion()`.
+   *
+   * `prefer_uhid` defaults to `is_uhid_supported()`, so the common case ("rich
+   * when possible, basic otherwise") needs no wiring. If the library was built
+   * without the uhid sources, the uinput pad is always returned regardless.
+   */
+  static Result<std::unique_ptr<Joypad>> create(TYPE kind, bool prefer_uhid = is_uhid_supported());
+  static Result<std::unique_ptr<Joypad>>
+  create(TYPE kind, const DeviceDefinition &device, bool prefer_uhid = is_uhid_supported());
+
+  /**
+   * The default device identity (name / vendor / product / version) for a
+   * TYPE — what create(kind, prefer_uhid) uses. Exposed so a consumer can
+   * start from it and tweak a field (e.g. device_uniq) without hard-coding the
+   * vendor/product ids itself.
+   */
+  static DeviceDefinition default_definition(TYPE kind);
+
+  /**
    * Given the nature of joypads we (might) have to simultaneously press and release multiple buttons.
    * In order to implement this, you can pass a single short: button_flags which represent the currently pressed
    * buttons in the joypad.
@@ -317,6 +398,70 @@ public:
   virtual void set_triggers(int16_t left, int16_t right) = 0;
 
   virtual void set_stick(STICK_POSITION stick_type, short x, short y) = 0;
+
+  // ---- Optional rich capabilities ----
+  //
+  // These default to no-ops / "unsupported" so a generic Joypad (e.g. the
+  // std::unique_ptr<Joypad> returned by Joypad::create()) is fully usable for
+  // every backend without the caller knowing the concrete type. Backends that
+  // implement a feature override the relevant method; the basic uinput pads
+  // inherit the no-ops. supports_motion() is the one capability a caller
+  // typically branches on (to avoid asking a client to stream sensor data a pad
+  // can't consume) — the setters themselves are always safe to call.
+
+  enum BATTERY_STATE : uint8_t {
+    BATTERY_DISCHARGING = 0x0,
+    BATTERY_CHARGHING = 0x1,
+    BATTERY_FULL = 0x2,
+    VOLTAGE_OR_TEMPERATURE_OUT_OF_RANGE = 0xA,
+    TEMPERATURE_ERROR = 0xB,
+    CHARGHING_ERROR = 0xF
+  };
+
+  /**
+   * Opaque adaptive-trigger blob sent to the controller. Some reverse-engineered
+   * documentation: https://gist.github.com/Nielk1/6d54cc2c00d2201ccb8c2720ad7538db
+   */
+  struct TriggerEffect {
+    /**
+     * 0x04 - Right trigger
+     * 0x08 - Left trigger
+     */
+    uint8_t event_flags;
+    uint8_t type_left;
+    uint8_t type_right;
+    std::array<uint8_t, 10> left = {};
+    std::array<uint8_t, 10> right = {};
+  };
+
+  static constexpr int touchpad_width = 1920;
+  static constexpr int touchpad_height = 1080;
+
+  /** Whether this pad forwards motion (accelerometer/gyroscope) to the host. */
+  virtual bool supports_motion() const {
+    return false;
+  }
+
+  virtual void set_on_rumble(const std::function<void(int low_freq, int high_freq)> & /* callback */) {}
+
+  /**
+   * Forward a gyroscope sample. Units are deg/s (the SDL / Moonlight
+   * convention); x/y/z follow SDL's sensor axis convention. No-op on pads
+   * without motion — gate on supports_motion().
+   */
+  virtual void set_gyro(float /* x */, float /* y */, float /* z */) {}
+
+  /**
+   * Forward an accelerometer sample. Units are m/s^2, inclusive of gravity;
+   * x/y/z follow SDL's sensor axis convention. No-op on pads without motion —
+   * gate on supports_motion().
+   */
+  virtual void set_accel(float /* x */, float /* y */, float /* z */) {}
+  virtual void place_finger(int /* finger_nr */, uint16_t /* x */, uint16_t /* y */) {}
+  virtual void release_finger(int /* finger_nr */) {}
+  virtual void set_battery(BATTERY_STATE /* state */, int /* percentage */) {}
+  virtual void set_on_led(const std::function<void(int r, int g, int b)> & /* callback */) {}
+  virtual void set_on_trigger_effect(const std::function<void(const TriggerEffect &)> & /* callback */) {}
 };
 
 class XboxOneJoypad : public Joypad {
@@ -334,6 +479,8 @@ public:
   ~XboxOneJoypad() override;
 
   std::vector<std::string> get_nodes() const override;
+  std::vector<UdevEvent> get_udev_events() const override;
+  std::vector<UdevHwDbEntry> get_udev_hw_db_entries() const override;
 
   void set_pressed_buttons(unsigned int newly_pressed) override;
   void set_triggers(int16_t left, int16_t right) override;
@@ -348,34 +495,6 @@ private:
   XboxOneJoypad();
 };
 
-class SwitchJoypad : public Joypad {
-public:
-  static Result<SwitchJoypad> create(const DeviceDefinition &device = {
-                                         .name = "Wolf Nintendo (virtual) pad",
-                                         // https://github.com/torvalds/linux/blob/master/drivers/hid/hid-ids.h#L981
-                                         .vendor_id = 0x057e,
-                                         .product_id = 0x2009,
-                                         .version = 0x8111});
-  SwitchJoypad(SwitchJoypad &&j) : _state(nullptr) {
-    std::swap(j._state, _state);
-  }
-  ~SwitchJoypad() override;
-
-  std::vector<std::string> get_nodes() const override;
-
-  void set_pressed_buttons(unsigned int newly_pressed) override;
-  void set_triggers(int16_t left, int16_t right) override;
-  void set_stick(STICK_POSITION stick_type, short x, short y) override;
-  void set_on_rumble(const std::function<void(int low_freq, int high_freq)> &callback);
-
-protected:
-  typedef struct XboxOneJoypadState SwitchJoypadState;
-  std::shared_ptr<SwitchJoypadState> _state;
-
-private:
-  SwitchJoypad();
-};
-
 class PS5Joypad : public Joypad {
 public:
   static Result<PS5Joypad>
@@ -383,10 +502,15 @@ public:
              .name = "Wolf DualSense (virtual) pad", .vendor_id = 0x054C, .product_id = 0x0CE6, .version = 0x8111});
   PS5Joypad(PS5Joypad &&j) noexcept : _state(nullptr) {
     std::swap(j._state, _state);
+    // The report pump is joinable (not detached) so the destructor can wait for it; it must
+    // travel with the state it writes to, otherwise the moved-from object would terminate() on a joinable thread.
+    std::swap(j._send_input_thread, _send_input_thread);
   }
   ~PS5Joypad() override;
 
   std::vector<std::string> get_nodes() const override;
+  std::vector<UdevEvent> get_udev_events() const override;
+  std::vector<UdevHwDbEntry> get_udev_hw_db_entries() const override;
 
   std::string get_mac_address() const;
 
@@ -395,58 +519,50 @@ public:
   void set_pressed_buttons(unsigned int newly_pressed) override;
   void set_triggers(int16_t left, int16_t right) override;
   void set_stick(STICK_POSITION stick_type, short x, short y) override;
-  void set_on_rumble(const std::function<void(int low_freq, int high_freq)> &callback);
+  void set_on_rumble(const std::function<void(int low_freq, int high_freq)> &callback) override;
 
-  static constexpr int touchpad_width = 1920;
-  static constexpr int touchpad_height = 1080;
-  void place_finger(int finger_nr, uint16_t x, uint16_t y);
-  void release_finger(int finger_nr);
+  bool supports_motion() const override {
+    return true;
+  }
+
+  void place_finger(int finger_nr, uint16_t x, uint16_t y) override;
+  void release_finger(int finger_nr) override;
 
   enum MOTION_TYPE : uint8_t {
-    ACCELERATION = 0x01,
-    GYROSCOPE = 0x02
+    ACCELERATION = 0x01, // sample in m/s^2 (inclusive of gravity)
+    GYROSCOPE = 0x02     // sample in rad/s (legacy scaling; set_gyro() takes deg/s)
   };
 
   /**
-   * Acceleration should report data in m/s^2 (inclusive of gravitational acceleration).
-   * Gyroscope should report data in deg/s.
+   * @deprecated Legacy DualSense-only motion API, kept for source backwards-
+   * compatibility (e.g. Sunshine, which pre-converts gyro to rad/s and calls
+   * this). Prefer the generic set_gyro() (deg/s) / set_accel() (m/s^2).
+   *
+   * GYROSCOPE expects rad/s, ACCELERATION m/s^2 (inclusive of gravity). This is
+   * now a thin shim: it forwards to set_accel() as-is and to set_gyro() after
+   * converting gyro rad/s -> deg/s, so there is a single motion code path.
    *
    * The x/y/z axis assignments follow SDL's convention documented here:
    * https://github.com/libsdl-org/SDL/blob/96720f335002bef62115e39327940df454d78f6c/include/SDL3/SDL_sensor.h#L80-L124
    */
   void set_motion(MOTION_TYPE type, float x, float y, float z);
 
-  enum BATTERY_STATE : uint8_t {
-    BATTERY_DISCHARGING = 0x0,
-    BATTERY_CHARGHING = 0x1,
-    BATTERY_FULL = 0x2,
-    VOLTAGE_OR_TEMPERATURE_OUT_OF_RANGE = 0xA,
-    TEMPERATURE_ERROR = 0xB,
-    CHARGHING_ERROR = 0xF
-  };
-
-  void set_battery(BATTERY_STATE state, int percentage);
-
-  void set_on_led(const std::function<void(int r, int g, int b)> &callback);
+  /**
+   * Forward a gyroscope sample, in deg/s (SDL / Moonlight convention). Converts
+   * deg->rad internally for the rad/s-calibrated DualSense HID report.
+   */
+  void set_gyro(float x, float y, float z) override;
 
   /**
-   * This is an opaque blob that is sent to the controller.
-   * There is some reversed engineered information here:
-   * https://gist.github.com/Nielk1/6d54cc2c00d2201ccb8c2720ad7538db
+   * Forward an accelerometer sample, in m/s^2 (inclusive of gravity).
    */
-  struct TriggerEffect {
-    /**
-     * 0x04 - Right trigger
-     * 0x08 - Left trigger
-     */
-    uint8_t event_flags;
-    uint8_t type_left;
-    uint8_t type_right;
-    std::array<uint8_t, 10> left = {};
-    std::array<uint8_t, 10> right = {};
-  };
+  void set_accel(float x, float y, float z) override;
 
-  void set_on_trigger_effect(const std::function<void(const TriggerEffect &)> &callback);
+  void set_battery(BATTERY_STATE state, int percentage) override;
+
+  void set_on_led(const std::function<void(int r, int g, int b)> &callback) override;
+
+  void set_on_trigger_effect(const std::function<void(const TriggerEffect &)> &callback) override;
 
 protected:
   typedef struct PS5JoypadState PS5JoypadState;
@@ -457,4 +573,70 @@ private:
 
   PS5Joypad(uint16_t vendor_id, const Mac &mac);
 };
+
+/**
+ * Basic uinput DualSense pad: buttons, sticks, triggers and rumble only — no
+ * touchpad / motion / battery / LED / adaptive triggers (those inherit the
+ * Joypad base no-ops). Universally available since it needs only uinput, so it
+ * is the fallback Joypad::create() picks when /dev/uhid isn't accessible.
+ */
+class PS5JoypadUinput : public Joypad {
+public:
+  static Result<PS5JoypadUinput>
+  create(const DeviceDefinition &device = {
+             .name = "Wolf DualSense (virtual) pad", .vendor_id = 0x054C, .product_id = 0x0CE6, .version = 0x8111});
+  PS5JoypadUinput(PS5JoypadUinput &&j) noexcept : _state(nullptr) {
+    std::swap(j._state, _state);
+  }
+  ~PS5JoypadUinput() override;
+
+  std::vector<std::string> get_nodes() const override;
+  std::vector<UdevEvent> get_udev_events() const override;
+  std::vector<UdevHwDbEntry> get_udev_hw_db_entries() const override;
+
+  void set_pressed_buttons(unsigned int newly_pressed) override;
+  void set_triggers(int16_t left, int16_t right) override;
+  void set_stick(STICK_POSITION stick_type, short x, short y) override;
+  void set_on_rumble(const std::function<void(int low_freq, int high_freq)> &callback) override;
+
+protected:
+  typedef struct PS5JoypadUinputState PS5JoypadUinputState;
+  std::shared_ptr<PS5JoypadUinputState> _state;
+
+private:
+  PS5JoypadUinput();
+};
+
+/**
+ * Basic uinput Nintendo pad: buttons (positionally remapped to the Xbox-style
+ * Joypad API, matching SwitchJoypad), sticks and rumble. No motion (inherits
+ * the base no-op + supports_motion() == false). uinput-only fallback.
+ */
+class SwitchJoypad : public Joypad {
+public:
+  static Result<SwitchJoypad>
+  create(const DeviceDefinition &device = {
+             .name = "Wolf Nintendo (virtual) pad", .vendor_id = 0x057e, .product_id = 0x2009, .version = 0x8111});
+  SwitchJoypad(SwitchJoypad &&j) noexcept : _state(nullptr) {
+    std::swap(j._state, _state);
+  }
+  ~SwitchJoypad() override;
+
+  std::vector<std::string> get_nodes() const override;
+  std::vector<UdevEvent> get_udev_events() const override;
+  std::vector<UdevHwDbEntry> get_udev_hw_db_entries() const override;
+
+  void set_pressed_buttons(unsigned int newly_pressed) override;
+  void set_triggers(int16_t left, int16_t right) override;
+  void set_stick(STICK_POSITION stick_type, short x, short y) override;
+  void set_on_rumble(const std::function<void(int low_freq, int high_freq)> &callback) override;
+
+protected:
+  typedef struct SwitchJoypadState SwitchJoypadState;
+  std::shared_ptr<SwitchJoypadState> _state;
+
+private:
+  SwitchJoypad();
+};
+
 } // namespace inputtino

--- a/include/inputtino/mac.hpp
+++ b/include/inputtino/mac.hpp
@@ -1,51 +1,44 @@
 #pragma once
 
 #include <array>
-#include <functional>
-#include <iomanip>
-#include <random>
-#include <sstream>
+#include <cstdint>
 #include <string>
 
 namespace inputtino {
 
+/**
+ * A 6-byte MAC address for inputtino virtual devices, with a small allocation
+ * pool so each virtual device gets a unique address (the kernel rejects
+ * duplicate MACs). The implementation lives in mac.cpp to keep this public
+ * header free of heavy includes.
+ */
 struct Mac {
   std::array<unsigned char, 6> bytes = {};
 
-  static Mac generate() {
-    auto rand = std::bind(std::uniform_int_distribution<unsigned char>{0, 0xFF},
-                          std::default_random_engine{std::random_device()()});
-    return {{rand(), rand(), rand(), rand(), rand(), rand()}};
-  }
+  /**
+   * Allocate the next free MAC with the inputtino prefix AA:BB:CC:00:xx:xx,
+   * avoiding collisions with both the internal pool and existing UHID devices.
+   * Thread-safe. Call release() when the device is destroyed.
+   */
+  static Mac generate();
 
-  static Mac parse(const std::string &str) {
-    Mac mac;
-    std::stringstream ss(str);
-    for (int i = 0; i < 6; ++i) {
-      unsigned int v = 0;
-      ss >> std::hex >> v;
-      mac.bytes[i] = static_cast<unsigned char>(v);
-      if (i < 5)
-        ss.ignore(1, ':');
-    }
-    return mac;
-  }
+  /** Return a MAC to the pool so it can be reused. */
+  static void release(const Mac &mac);
 
-  std::string to_string() const {
-    std::ostringstream ss;
-    for (int i = 0; i < 6; ++i) {
-      if (i > 0)
-        ss << ':';
-      ss << std::hex << std::setfill('0') << std::setw(2) << static_cast<unsigned int>(bytes[i]);
-    }
-    return ss.str();
-  }
+  /** Parse a "xx:xx:xx:xx:xx:xx" string. */
+  static Mac parse(const std::string &str);
+
+  /** Format as "xx:xx:xx:xx:xx:xx". */
+  std::string to_string() const;
 
   bool matches(const std::string &str) const {
     return bytes == parse(str).bytes;
   }
   bool operator==(const Mac &other) const {
     return bytes == other.bytes;
+  }
+  bool operator!=(const Mac &other) const {
+    return bytes != other.bytes;
   }
 };
 

--- a/include/inputtino/mac.hpp
+++ b/include/inputtino/mac.hpp
@@ -2,37 +2,34 @@
 
 #include <array>
 #include <cstdint>
+#include <inputtino/result.hpp>
 #include <string>
 
 namespace inputtino {
 
 /**
- * A 6-byte MAC address for inputtino virtual devices, with a small allocation
- * pool so each virtual device gets a unique address (the kernel rejects
- * duplicate MACs). The implementation lives in mac.cpp to keep this public
- * header free of heavy includes.
+ * A 6-byte MAC address for inputtino virtual devices. Addresses are handed
+ * out from a monotonically increasing counter (each virtual device needs a
+ * unique address; the kernel rejects duplicate MACs).
  */
 struct Mac {
   std::array<unsigned char, 6> bytes = {};
 
   /**
    * Allocate the next free MAC with the inputtino prefix AA:BB:CC:00:xx:xx,
-   * avoiding collisions with both the internal pool and existing UHID devices.
-   * Thread-safe. Call release() when the device is destroyed.
+   * skipping any address already active on the system. Thread-safe.
    */
-  static Mac generate();
-
-  /** Return a MAC to the pool so it can be reused. */
-  static void release(const Mac &mac);
+  static Result<Mac> generate();
 
   /** Parse a "xx:xx:xx:xx:xx:xx" string. */
-  static Mac parse(const std::string &str);
+  static Result<Mac> parse(const std::string &str);
 
   /** Format as "xx:xx:xx:xx:xx:xx". */
   std::string to_string() const;
 
   bool matches(const std::string &str) const {
-    return bytes == parse(str).bytes;
+    auto parsed = parse(str);
+    return parsed && bytes == (*parsed).bytes;
   }
   bool operator==(const Mac &other) const {
     return bytes == other.bytes;

--- a/include/inputtino/mac.hpp
+++ b/include/inputtino/mac.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <array>
+#include <functional>
+#include <iomanip>
+#include <random>
+#include <sstream>
+#include <string>
+
+namespace inputtino {
+
+struct Mac {
+  std::array<unsigned char, 6> bytes = {};
+
+  static Mac generate() {
+    auto rand = std::bind(std::uniform_int_distribution<unsigned char>{0, 0xFF},
+                          std::default_random_engine{std::random_device()()});
+    return {{rand(), rand(), rand(), rand(), rand(), rand()}};
+  }
+
+  static Mac parse(const std::string &str) {
+    Mac mac;
+    std::stringstream ss(str);
+    for (int i = 0; i < 6; ++i) {
+      unsigned int v = 0;
+      ss >> std::hex >> v;
+      mac.bytes[i] = static_cast<unsigned char>(v);
+      if (i < 5)
+        ss.ignore(1, ':');
+    }
+    return mac;
+  }
+
+  std::string to_string() const {
+    std::ostringstream ss;
+    for (int i = 0; i < 6; ++i) {
+      if (i > 0)
+        ss << ':';
+      ss << std::hex << std::setfill('0') << std::setw(2) << static_cast<unsigned int>(bytes[i]);
+    }
+    return ss.str();
+  }
+
+  bool matches(const std::string &str) const {
+    return bytes == parse(str).bytes;
+  }
+  bool operator==(const Mac &other) const {
+    return bytes == other.bytes;
+  }
+};
+
+} // namespace inputtino

--- a/src/host_capability.cpp
+++ b/src/host_capability.cpp
@@ -74,9 +74,19 @@ Result<std::unique_ptr<Joypad>> Joypad::create(Joypad::TYPE kind, const DeviceDe
 #endif
     return as_joypad(PS5JoypadUinput::create(device));
   case Joypad::TYPE::NINTENDO:
-    // uinput-only for now; the uhid Switch backend lands in a follow-up PR.
+#ifdef INPUTTINO_USE_UHID
+    if (prefer_uhid) {
+      if (auto pad = SwitchJoypad::create(device)) {
+        return std::unique_ptr<Joypad>(std::make_unique<SwitchJoypad>(std::move(*pad)));
+      } else {
+        std::cerr << "inputtino: uhid Switch joypad creation failed (" << pad.getErrorMessage()
+                  << "), falling back to the uinput backend" << std::endl;
+      }
+    }
+#else
     (void)prefer_uhid;
-    return as_joypad(SwitchJoypad::create(device));
+#endif
+    return as_joypad(SwitchJoypadUinput::create(device));
   }
   return Error("Joypad::create: unknown Joypad::TYPE");
 }

--- a/src/host_capability.cpp
+++ b/src/host_capability.cpp
@@ -1,0 +1,84 @@
+// Runtime probes for host-level input capabilities plus the runtime joypad
+// factory, used by callers that want to pick between uhid- and uinput-backed
+// virtual devices based on what the kernel actually exposes here.
+
+#include <fcntl.h>
+#include <inputtino/input.hpp>
+#include <iostream>
+#include <memory>
+#include <unistd.h>
+
+namespace inputtino {
+
+bool is_uhid_supported() {
+  // Cached once per process — UHID node presence doesn't change at
+  // runtime on any sane host, and probing on every controller
+  // creation would add ~200us of open/close per join.
+  static const bool supported = []() {
+    int fd = open("/dev/uhid", O_RDWR | O_CLOEXEC);
+    if (fd < 0) {
+      return false;
+    }
+    close(fd);
+    return true;
+  }();
+  return supported;
+}
+
+namespace {
+
+// Wrap a concrete Result<T> into a Result<unique_ptr<Joypad>>, moving the
+// created pad onto the heap and up-casting to the Joypad base.
+template <typename T> Result<std::unique_ptr<Joypad>> as_joypad(Result<T> created) {
+  if (!created) {
+    return Error(created.getErrorMessage());
+  }
+  return std::unique_ptr<Joypad>(std::make_unique<T>(std::move(*created)));
+}
+
+} // namespace
+
+DeviceDefinition Joypad::default_definition(Joypad::TYPE kind) {
+  switch (kind) {
+  case Joypad::TYPE::XBOX:
+    return {.name = "Wolf X-Box One (virtual) pad", .vendor_id = 0x045E, .product_id = 0x02EA, .version = 0x0408};
+  case Joypad::TYPE::PS:
+    return {.name = "Wolf DualSense (virtual) pad", .vendor_id = 0x054C, .product_id = 0x0CE6, .version = 0x8111};
+  case Joypad::TYPE::NINTENDO:
+    return {.name = "Wolf Nintendo (virtual) pad", .vendor_id = 0x057e, .product_id = 0x2009, .version = 0x8111};
+  }
+  return {};
+}
+
+Result<std::unique_ptr<Joypad>> Joypad::create(Joypad::TYPE kind, bool prefer_uhid) {
+  return create(kind, default_definition(kind), prefer_uhid);
+}
+
+Result<std::unique_ptr<Joypad>> Joypad::create(Joypad::TYPE kind, const DeviceDefinition &device, bool prefer_uhid) {
+  switch (kind) {
+  case Joypad::TYPE::XBOX:
+    // uinput-only; there is no uhid Xbox backend.
+    return as_joypad(XboxOneJoypad::create(device));
+  case Joypad::TYPE::PS:
+#ifdef INPUTTINO_USE_UHID
+    if (prefer_uhid) {
+      if (auto pad = PS5Joypad::create(device)) {
+        return std::unique_ptr<Joypad>(std::make_unique<PS5Joypad>(std::move(*pad)));
+      } else {
+        std::cerr << "inputtino: uhid PS5 joypad creation failed (" << pad.getErrorMessage()
+                  << "), falling back to the uinput backend" << std::endl;
+      }
+    }
+#else
+    (void)prefer_uhid;
+#endif
+    return as_joypad(PS5JoypadUinput::create(device));
+  case Joypad::TYPE::NINTENDO:
+    // uinput-only for now; the uhid Switch backend lands in a follow-up PR.
+    (void)prefer_uhid;
+    return as_joypad(SwitchJoypad::create(device));
+  }
+  return Error("Joypad::create: unknown Joypad::TYPE");
+}
+
+} // namespace inputtino

--- a/src/host_capability.cpp
+++ b/src/host_capability.cpp
@@ -44,6 +44,11 @@ DeviceDefinition Joypad::default_definition(Joypad::TYPE kind) {
     return {.name = "Wolf X-Box One (virtual) pad", .vendor_id = 0x045E, .product_id = 0x02EA, .version = 0x0408};
   case Joypad::TYPE::PS:
     return {.name = "Wolf DualSense (virtual) pad", .vendor_id = 0x054C, .product_id = 0x0CE6, .version = 0x8111};
+  case Joypad::TYPE::JOYCON_LEFT:
+    // hid-nintendo keys the Joy-Con side off the product id (0x2006 = left).
+    return {.name = "Wolf Joy-Con (L) (virtual) pad", .vendor_id = 0x057e, .product_id = 0x2006, .version = 0x8111};
+  case Joypad::TYPE::JOYCON_RIGHT:
+    return {.name = "Wolf Joy-Con (R) (virtual) pad", .vendor_id = 0x057e, .product_id = 0x2007, .version = 0x8111};
   case Joypad::TYPE::NINTENDO:
     return {.name = "Wolf Nintendo (virtual) pad", .vendor_id = 0x057e, .product_id = 0x2009, .version = 0x8111};
   }
@@ -73,6 +78,10 @@ Result<std::unique_ptr<Joypad>> Joypad::create(Joypad::TYPE kind, const DeviceDe
     (void)prefer_uhid;
 #endif
     return as_joypad(PS5JoypadUinput::create(device));
+  // Pro Controller and the two Joy-Cons are the same hid-nintendo pad; the
+  // SwitchJoypad picks Pro / L / R from device.product_id (see default_definition).
+  case Joypad::TYPE::JOYCON_LEFT:
+  case Joypad::TYPE::JOYCON_RIGHT:
   case Joypad::TYPE::NINTENDO:
 #ifdef INPUTTINO_USE_UHID
     if (prefer_uhid) {

--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -4,7 +4,7 @@
 #include <fstream>
 #include <iomanip>
 #include <mutex>
-#include <set>
+#include <regex>
 #include <sstream>
 
 namespace inputtino {
@@ -16,10 +16,6 @@ namespace {
 Mac from_id(uint16_t id) {
   return {
       {0xAA, 0xBB, 0xCC, 0x00, static_cast<unsigned char>((id >> 8) & 0xFF), static_cast<unsigned char>(id & 0xFF)}};
-}
-
-uint16_t to_id(const Mac &mac) {
-  return (static_cast<uint16_t>(mac.bytes[4]) << 8) | static_cast<uint16_t>(mac.bytes[5]);
 }
 
 // Check whether a MAC is already in use by an existing UHID device.
@@ -49,35 +45,39 @@ bool is_active_on_system(const Mac &mac) {
   return false;
 }
 
-std::set<uint16_t> &pool() {
-  static std::set<uint16_t> instance;
+uint16_t &next_id() {
+  static uint16_t instance = 1;
   return instance;
 }
 
-std::mutex &pool_mutex() {
+std::mutex &next_id_mutex() {
   static std::mutex instance;
   return instance;
 }
 
 } // namespace
 
-Mac Mac::generate() {
-  std::lock_guard<std::mutex> lock(pool_mutex());
-  auto &used = pool();
-  uint16_t id = 1;
-  while (used.count(id) || is_active_on_system(from_id(id))) {
+Result<Mac> Mac::generate() {
+  std::lock_guard<std::mutex> lock(next_id_mutex());
+  auto &id = next_id();
+  auto start = id;
+  while (is_active_on_system(from_id(id))) {
     ++id;
+    if (id == start) {
+      return Error("Exhausted the MAC address space");
+    }
   }
-  used.insert(id);
-  return from_id(id);
+  auto mac = from_id(id);
+  ++id;
+  return mac;
 }
 
-void Mac::release(const Mac &mac) {
-  std::lock_guard<std::mutex> lock(pool_mutex());
-  pool().erase(to_id(mac));
-}
+Result<Mac> Mac::parse(const std::string &str) {
+  static const std::regex mac_format("^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$");
+  if (!std::regex_match(str, mac_format)) {
+    return Error("Invalid MAC address: " + str);
+  }
 
-Mac Mac::parse(const std::string &str) {
   Mac mac;
   std::stringstream ss(str);
   for (int i = 0; i < 6; ++i) {

--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -1,0 +1,103 @@
+#include <inputtino/mac.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <mutex>
+#include <set>
+#include <sstream>
+
+namespace inputtino {
+
+namespace {
+
+// Prefix: AA:BB:CC:00:xx:xx — distinctive enough to avoid collisions with
+// Docker (02:42:xx), VMs, or real hardware.
+Mac from_id(uint16_t id) {
+  return {
+      {0xAA, 0xBB, 0xCC, 0x00, static_cast<unsigned char>((id >> 8) & 0xFF), static_cast<unsigned char>(id & 0xFF)}};
+}
+
+uint16_t to_id(const Mac &mac) {
+  return (static_cast<uint16_t>(mac.bytes[4]) << 8) | static_cast<uint16_t>(mac.bytes[5]);
+}
+
+// Check whether a MAC is already in use by an existing UHID device.
+bool is_active_on_system(const Mac &mac) {
+  const std::string base = "/sys/devices/virtual/misc/uhid";
+  if (!std::filesystem::exists(base)) {
+    return false;
+  }
+  for (const auto &uhid_entry : std::filesystem::directory_iterator{base}) {
+    if (!uhid_entry.is_directory())
+      continue;
+    auto input_path = uhid_entry.path() / "input";
+    if (!std::filesystem::exists(input_path))
+      continue;
+    for (const auto &dev_entry : std::filesystem::directory_iterator{input_path}) {
+      auto uniq_path = dev_entry.path() / "uniq";
+      if (!std::filesystem::exists(uniq_path))
+        continue;
+      std::ifstream f{uniq_path};
+      std::string uniq;
+      std::getline(f, uniq);
+      if (mac.matches(uniq)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+std::set<uint16_t> &pool() {
+  static std::set<uint16_t> instance;
+  return instance;
+}
+
+std::mutex &pool_mutex() {
+  static std::mutex instance;
+  return instance;
+}
+
+} // namespace
+
+Mac Mac::generate() {
+  std::lock_guard<std::mutex> lock(pool_mutex());
+  auto &used = pool();
+  uint16_t id = 1;
+  while (used.count(id) || is_active_on_system(from_id(id))) {
+    ++id;
+  }
+  used.insert(id);
+  return from_id(id);
+}
+
+void Mac::release(const Mac &mac) {
+  std::lock_guard<std::mutex> lock(pool_mutex());
+  pool().erase(to_id(mac));
+}
+
+Mac Mac::parse(const std::string &str) {
+  Mac mac;
+  std::stringstream ss(str);
+  for (int i = 0; i < 6; ++i) {
+    unsigned int v = 0;
+    ss >> std::hex >> v;
+    mac.bytes[i] = static_cast<unsigned char>(v);
+    if (i < 5)
+      ss.ignore(1, ':');
+  }
+  return mac;
+}
+
+std::string Mac::to_string() const {
+  std::ostringstream ss;
+  for (int i = 0; i < 6; ++i) {
+    if (i > 0)
+      ss << ':';
+    ss << std::hex << std::setfill('0') << std::setw(2) << static_cast<unsigned int>(bytes[i]);
+  }
+  return ss.str();
+}
+
+} // namespace inputtino

--- a/src/udev_helpers.hpp
+++ b/src/udev_helpers.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+// Helpers for building the synthetic udev event + hwdb metadata returned by
+// Joypad::get_udev_events() / get_udev_hw_db_entries(). A virtual device shows
+// up as a bare /dev/input node with no udev database backing it; a consumer
+// running apps inside a namespace replays these so libudev/SDL recognise the
+// device as real hardware. Kept header-only (inline) and free of libevdev so
+// both the uinput and uhid joypad backends can use them.
+
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+#include <map>
+#include <string>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <utility>
+
+namespace inputtino {
+
+inline std::pair<unsigned int, unsigned int> get_major_minor(const std::string &devnode) {
+  struct stat buf {};
+  if (stat(devnode.c_str(), &buf) == -1) {
+    std::cerr << "inputtino: unable to stat " << devnode << std::endl;
+    return {};
+  }
+  if (!S_ISCHR(buf.st_mode)) {
+    std::cerr << "inputtino: device " << devnode << " is not a character device" << std::endl;
+    return {};
+  }
+  return {major(buf.st_rdev), minor(buf.st_rdev)};
+}
+
+// hwdb entries are keyed by a "c<major>:<minor>" filename (character device).
+inline std::string gen_udev_hw_db_filename(const std::string &dev_node) {
+  auto [dev_major, dev_minor] = get_major_minor(dev_node);
+  return "c" + std::to_string(dev_major) + ":" + std::to_string(dev_minor);
+}
+
+// The properties every input udev event carries; callers add the device-class
+// specific keys (ID_INPUT_JOYSTICK, ID_INPUT_ACCELEROMETER, ...) on top.
+inline std::map<std::string, std::string>
+gen_udev_base_event(const std::string &devnode, const std::string &syspath, const std::string &action = "add") {
+  auto [dev_major, dev_minor] = get_major_minor(devnode);
+  auto now = std::chrono::system_clock::now();
+  auto timestamp = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+  return {
+      {"ACTION", action},
+      {"SEQNUM", "7"}, // We don't keep global state, let's hope it's not used
+      {"USEC_INITIALIZED", std::to_string(timestamp)},
+      {"SUBSYSTEM", "input"},
+      {"ID_INPUT", "1"},
+      {"ID_SERIAL", "noserial"},
+      {"TAGS", ":seat:uaccess:"},
+      {"CURRENT_TAGS", ":seat:uaccess:"},
+      {"DEVNAME", devnode},
+      {"DEVPATH", syspath},
+      {"MAJOR", std::to_string(dev_major)},
+      {"MINOR", std::to_string(dev_minor)},
+  };
+}
+
+} // namespace inputtino

--- a/src/uhid/include/uhid/joypad_common.hpp
+++ b/src/uhid/include/uhid/joypad_common.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+// Shared plumbing for the uhid joypad backends (PS5 / Switch Pro). Both create a
+// uhid device, run a report-pump thread, and guard the device with a mutex. Only
+// the report layout (send_report) and
+// the pump cadence differ, so the lifecycle lives here once.
+
+#include <chrono>
+#include <cstdio>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <uhid/uhid.hpp>
+#include <vector>
+
+namespace inputtino::uhid_joypad {
+
+/**
+ * State common to every uhid joypad. Concrete joypad states inherit this and add
+ * their report-specific fields. `mtx` serialises access to `dev` between the
+ * report-pump thread and the client-driven control thread (set_motion /
+ * buttons).
+ */
+struct CommonState {
+  std::shared_ptr<uhid::Device> dev;
+  uhid::DeviceDefinition def = {};
+  std::mutex mtx;
+  bool stop_repeat_thread = false;
+};
+
+/**
+ * Block until the kernel has exposed the device's sysfs input/hidraw nodes (or we
+ * give up after max_attempts). Callers that read get_udev_events()/get_nodes()
+ * straight after create() (e.g. plugging the pad into a container)
+ * would otherwise see an empty device and it wouldn't enumerate.
+ */
+inline void wait_for_sys_nodes(const std::function<std::vector<std::string>()> &get_sys_nodes,
+                               int max_attempts = 20,
+                               std::chrono::milliseconds interval = std::chrono::milliseconds(50)) {
+  for (int attempt = 0; attempt < max_attempts && get_sys_nodes().empty(); ++attempt) {
+    std::this_thread::sleep_for(interval);
+  }
+}
+
+/**
+ * Start the report-pump thread: re-sends the HID input report every `interval` so
+ * the device stays "live" for readers even when its state hasn't changed. The
+ * thread holds a shared_ptr to the state so it stays valid across joypad moves,
+ * and exits once state->stop_repeat_thread is set.
+ */
+template <typename State>
+std::thread
+start_report_pump(std::shared_ptr<State> state, std::function<void(State &)> send, std::chrono::milliseconds interval) {
+  return std::thread([state, send = std::move(send), interval]() {
+    while (!state->stop_repeat_thread) {
+      send(*state);
+      std::this_thread::sleep_for(interval);
+    }
+  });
+}
+
+} // namespace inputtino::uhid_joypad

--- a/src/uhid/include/uhid/protected_types.hpp
+++ b/src/uhid/include/uhid/protected_types.hpp
@@ -8,17 +8,7 @@
 namespace inputtino {
 struct PS5JoypadState {
   std::shared_ptr<uhid::Device> dev;
-  /**
-   * This will be the MAC address of the device
-   *
-   * IMPORTANT: this needs to be unique for each virtual device,
-   * otherwise the kernel driver will return an error:
-   * "Duplicate device found for MAC address XX:XX:XX:XX"
-   *
-   * We also use this information internally to unique match a device with the
-   * /dev/input/devXX files; see get_nodes()
-   */
-  Mac mac = {{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
+  Mac mac;
   uint16_t vendor_id;
 
   uhid::dualsense_input_report current_state = {};

--- a/src/uhid/include/uhid/protected_types.hpp
+++ b/src/uhid/include/uhid/protected_types.hpp
@@ -18,7 +18,7 @@ struct PS5JoypadState {
    * We also use this information internally to unique match a device with the
    * /dev/input/devXX files; see get_nodes()
    */
-  unsigned char mac_address[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+  std::array<unsigned char, 6> mac = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
   uint16_t vendor_id;
 
   uhid::dualsense_input_report current_state = {};

--- a/src/uhid/include/uhid/protected_types.hpp
+++ b/src/uhid/include/uhid/protected_types.hpp
@@ -4,11 +4,31 @@
 #include <optional>
 #include <uhid/joypad_common.hpp>
 #include <uhid/ps5.hpp>
+#include <uhid/switch.hpp>
 #include <uhid/uhid.hpp>
 
 namespace inputtino {
 // dev / def / mtx / stop_repeat_thread live in uhid_joypad::CommonState, shared
 // with PS5JoypadState below and driven by the helpers in uhid/joypad_common.hpp.
+struct SwitchJoypadState : uhid_joypad::CommonState {
+  Mac mac;
+  uint16_t vendor_id;
+  uint16_t product_id;
+  uint8_t controller_type = uhid::JOYCON_CTLR_TYPE_PRO;
+
+  uint8_t buttons[3] = {};
+  uint16_t lx = uhid::SWITCH_AXIS_CENTER;
+  uint16_t ly = uhid::SWITCH_AXIS_CENTER;
+  uint16_t rx = uhid::SWITCH_AXIS_CENTER;
+  uint16_t ry = uhid::SWITCH_AXIS_CENTER;
+  uhid::switch_imu_sample imu[3] = {};
+
+  uint8_t timer = 0;
+  uint8_t report_mode = uhid::SWITCH_REPORT_MODE_STANDARD_FULL;
+  bool imu_enabled = false;
+  bool vibration_enabled = false;
+  std::optional<std::function<void(int, int)>> on_rumble = std::nullopt;
+};
 
 struct PS5JoypadState : uhid_joypad::CommonState {
   // MAC allocated from the pooled Mac type (switch-pro-controller work);

--- a/src/uhid/include/uhid/protected_types.hpp
+++ b/src/uhid/include/uhid/protected_types.hpp
@@ -18,7 +18,7 @@ struct PS5JoypadState {
    * We also use this information internally to unique match a device with the
    * /dev/input/devXX files; see get_nodes()
    */
-  std::array<unsigned char, 6> mac = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+  Mac mac = {{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
   uint16_t vendor_id;
 
   uhid::dualsense_input_report current_state = {};

--- a/src/uhid/include/uhid/protected_types.hpp
+++ b/src/uhid/include/uhid/protected_types.hpp
@@ -2,12 +2,17 @@
 #include <functional>
 #include <inputtino/input.hpp>
 #include <optional>
+#include <uhid/joypad_common.hpp>
 #include <uhid/ps5.hpp>
 #include <uhid/uhid.hpp>
 
 namespace inputtino {
-struct PS5JoypadState {
-  std::shared_ptr<uhid::Device> dev;
+// dev / def / mtx / stop_repeat_thread live in uhid_joypad::CommonState, shared
+// with PS5JoypadState below and driven by the helpers in uhid/joypad_common.hpp.
+
+struct PS5JoypadState : uhid_joypad::CommonState {
+  // MAC allocated from the pooled Mac type (switch-pro-controller work);
+  // dev_paths derive from this so the /dev/input/* layout stays stable.
   Mac mac;
   uint16_t vendor_id;
 
@@ -20,7 +25,6 @@ struct PS5JoypadState {
   uint32_t last_left_trigger_event = 0;
   uint32_t last_right_trigger_event = 0;
 
-  bool stop_repeat_thread = false;
   bool is_bluetooth = true;
 };
 } // namespace inputtino

--- a/src/uhid/include/uhid/switch.hpp
+++ b/src/uhid/include/uhid/switch.hpp
@@ -26,8 +26,12 @@ static constexpr uint8_t SWITCH_ACK = 0x80;
 static constexpr uint8_t SWITCH_ACK_DEV_INFO = 0x82;
 static constexpr uint8_t SWITCH_ACK_SPI_FLASH_READ = 0x90;
 
+static constexpr uint8_t JOYCON_CTLR_TYPE_JCL = 0x01;
+static constexpr uint8_t JOYCON_CTLR_TYPE_JCR = 0x02;
 static constexpr uint8_t JOYCON_CTLR_TYPE_PRO = 0x03;
 
+static constexpr uint16_t JOYCON_PID_LEFT = 0x2006;
+static constexpr uint16_t JOYCON_PID_RIGHT = 0x2007;
 static constexpr uint16_t JOYCON_PID_PRO = 0x2009;
 
 static constexpr uint32_t JC_CAL_USR_LEFT_MAGIC_ADDR = 0x8010;

--- a/src/uhid/include/uhid/switch.hpp
+++ b/src/uhid/include/uhid/switch.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace uhid {
+
+static constexpr uint8_t SWITCH_INPUT_REPORT_SUBCOMMAND_REPLY = 0x21;
+static constexpr uint8_t SWITCH_INPUT_REPORT_STANDARD_FULL = 0x30;
+static constexpr uint8_t SWITCH_OUTPUT_REPORT_RUMBLE_AND_SUBCOMMAND = 0x01;
+static constexpr uint8_t SWITCH_OUTPUT_REPORT_RUMBLE_ONLY = 0x10;
+
+static constexpr uint8_t SWITCH_REPORT_MODE_STANDARD_FULL = 0x30;
+
+static constexpr uint8_t SWITCH_SUBCMD_ENABLE_VIBRATION = 0x48;
+static constexpr uint8_t SWITCH_SUBCMD_ENABLE_IMU = 0x40;
+static constexpr uint8_t SWITCH_SUBCMD_SET_INPUT_REPORT_MODE = 0x03;
+static constexpr uint8_t SWITCH_SUBCMD_REQ_DEV_INFO = 0x02;
+static constexpr uint8_t SWITCH_SUBCMD_SPI_FLASH_READ = 0x10;
+static constexpr uint8_t SWITCH_SUBCMD_SET_PLAYER_LIGHTS = 0x30;
+static constexpr uint8_t SWITCH_SUBCMD_GET_PLAYER_LIGHTS = 0x31;
+static constexpr uint8_t SWITCH_SUBCMD_SET_HOME_LIGHT = 0x38;
+
+static constexpr uint8_t SWITCH_ACK = 0x80;
+static constexpr uint8_t SWITCH_ACK_DEV_INFO = 0x82;
+static constexpr uint8_t SWITCH_ACK_SPI_FLASH_READ = 0x90;
+
+static constexpr uint8_t JOYCON_CTLR_TYPE_PRO = 0x03;
+
+static constexpr uint16_t JOYCON_PID_PRO = 0x2009;
+
+static constexpr uint32_t JC_CAL_USR_LEFT_MAGIC_ADDR = 0x8010;
+static constexpr uint32_t JC_CAL_USR_RIGHT_MAGIC_ADDR = 0x801B;
+static constexpr uint32_t JC_CAL_FCT_DATA_LEFT_ADDR = 0x603D;
+static constexpr uint32_t JC_CAL_FCT_DATA_RIGHT_ADDR = 0x6046;
+static constexpr uint32_t JC_IMU_CAL_FCT_DATA_ADDR = 0x6020;
+static constexpr uint32_t JC_IMU_CAL_USR_MAGIC_ADDR = 0x8026;
+
+// 12-bit stick axis range: full range 0..4095, natural center at 2048.
+static constexpr int SWITCH_AXIS_MAX = 4095;
+static constexpr int SWITCH_AXIS_CENTER = 2048;
+static constexpr float SWITCH_STANDARD_GRAVITY_CONST = 9.80665f;
+static constexpr int16_t SWITCH_ACCEL_SCALE = 4096;
+static constexpr int16_t SWITCH_GYRO_SCALE = 16;
+
+// IMU calibration: identity offsets so hid-nintendo passes raw values through unchanged.
+static constexpr int16_t SWITCH_IMU_ACCEL_OFFSET = 0;
+static constexpr int16_t SWITCH_IMU_ACCEL_SCALE_CAL = 16384;
+static constexpr int16_t SWITCH_IMU_GYRO_OFFSET = 0;
+static constexpr int16_t SWITCH_IMU_GYRO_SCALE_CAL = 13371;
+
+// Bluetooth report descriptor for Nintendo Switch Pro Controller.
+static constexpr unsigned char switch_rdesc_bt[] = {
+    0x05, 0x01, 0x09, 0x05, 0xA1, 0x01, 0x85, 0x30, 0x05, 0x01, 0x05, 0x09, 0x19, 0x01, 0x29, 0x0A, 0x15, 0x00, 0x25,
+    0x01, 0x75, 0x01, 0x95, 0x0A, 0x55, 0x00, 0x65, 0x00, 0x81, 0x02, 0x05, 0x09, 0x19, 0x0B, 0x29, 0x0E, 0x15, 0x00,
+    0x25, 0x01, 0x75, 0x01, 0x95, 0x04, 0x81, 0x02, 0x75, 0x01, 0x95, 0x02, 0x81, 0x03, 0x0B, 0x01, 0x00, 0x01, 0x00,
+    0xA1, 0x00, 0x0B, 0x30, 0x00, 0x01, 0x00, 0x0B, 0x31, 0x00, 0x01, 0x00, 0x0B, 0x32, 0x00, 0x01, 0x00, 0x0B, 0x35,
+    0x00, 0x01, 0x00, 0x15, 0x00, 0x27, 0xFF, 0x0F, 0x00, 0x00, 0x75, 0x10, 0x95, 0x04, 0x81, 0x02, 0xC0, 0x0B, 0x39,
+    0x00, 0x01, 0x00, 0x15, 0x00, 0x25, 0x07, 0x35, 0x00, 0x46, 0x3B, 0x01, 0x65, 0x14, 0x75, 0x04, 0x95, 0x01, 0x81,
+    0x42, 0x65, 0x00, 0x05, 0x09, 0x19, 0x0F, 0x29, 0x12, 0x15, 0x00, 0x25, 0x01, 0x75, 0x01, 0x95, 0x04, 0x81, 0x02,
+    0x75, 0x08, 0x95, 0x34, 0x81, 0x03, 0x06, 0x00, 0xFF, 0x85, 0x21, 0x09, 0x01, 0x75, 0x08, 0x95, 0x3F, 0x81, 0x03,
+    0x85, 0x81, 0x09, 0x02, 0x75, 0x08, 0x95, 0x3F, 0x81, 0x03, 0x85, 0x01, 0x09, 0x03, 0x75, 0x08, 0x95, 0x3F, 0x91,
+    0x83, 0x85, 0x10, 0x09, 0x04, 0x75, 0x08, 0x95, 0x3F, 0x91, 0x83, 0x85, 0x80, 0x09, 0x05, 0x75, 0x08, 0x95, 0x3F,
+    0x91, 0x83, 0x85, 0x82, 0x09, 0x06, 0x75, 0x08, 0x95, 0x3F, 0x91, 0x83, 0xC0};
+
+#pragma pack(push, 1)
+
+// Output report sent by the host to the controller
+struct switch_rumble_data {
+  uint8_t freq_high; // high-band frequency
+  uint8_t amp_high;  // high-band amplitude, encoded in [0x00, 0xC8]
+  uint8_t freq_low;  // low-band frequency; bit 7 is the low-amp half-step flag
+  uint8_t amp_low;   // low-band amplitude (lower byte)
+};
+
+// Report 0x10: rumble data only (no subcommand)
+struct switch_output_report_rumble_only {
+  uint8_t report_id; // SWITCH_OUTPUT_REPORT_RUMBLE_ONLY (0x10)
+  uint8_t packet_number;
+  switch_rumble_data left;
+  switch_rumble_data right;
+};
+static_assert(sizeof(switch_output_report_rumble_only) == 10);
+
+// Report 0x01: rumble data + subcommand (subcmd_data follows immediately after this struct)
+struct switch_output_report_rumble_subcmd {
+  uint8_t report_id; // SWITCH_OUTPUT_REPORT_RUMBLE_AND_SUBCOMMAND (0x01)
+  uint8_t packet_number;
+  switch_rumble_data left;
+  switch_rumble_data right;
+  uint8_t subcmd_id;
+};
+static_assert(sizeof(switch_output_report_rumble_subcmd) == 11);
+
+struct switch_standard_input_prefix {
+  uint8_t report_id;
+  uint8_t timer;
+  uint8_t bat_con;
+  uint8_t button_status[3];
+  uint8_t left_stick[3];
+  uint8_t right_stick[3];
+  uint8_t vibrator_input;
+};
+
+struct switch_imu_sample {
+  int16_t accel[3];
+  int16_t gyro[3];
+};
+
+struct switch_input_report {
+  switch_standard_input_prefix prefix;
+  switch_imu_sample imu[3];
+};
+
+struct switch_subcmd_reply_report {
+  switch_standard_input_prefix prefix;
+  uint8_t ack;
+  uint8_t subcmd_id;
+  uint8_t data[35];
+};
+#pragma pack(pop)
+
+} // namespace uhid

--- a/src/uhid/include/uhid/uhid.hpp
+++ b/src/uhid/include/uhid/uhid.hpp
@@ -173,4 +173,26 @@ inline inputtino::Result<Device> Device::create(const DeviceDefinition &definiti
  */
 std::vector<std::string> find_uhid_sys_nodes(uint16_t vendor_id, const inputtino::Mac &mac);
 
+/**
+ * Map sysfs input node paths to /dev/input/ device paths (event*, js*).
+ */
+static std::vector<std::string> sys_nodes_to_dev_paths(const std::vector<std::string> &sys_nodes) {
+  std::vector<std::string> dev_paths;
+  for (const auto &sys_entry : sys_nodes) {
+    if (!std::filesystem::exists(sys_entry)) {
+      continue;
+    }
+    for (const auto &dev_node : std::filesystem::directory_iterator{sys_entry}) {
+      if (!dev_node.is_directory()) {
+        continue;
+      }
+      auto name = dev_node.path().filename().string();
+      if (name.rfind("event", 0) == 0 || name.rfind("js", 0) == 0) {
+        dev_paths.push_back(("/dev/input/" / dev_node.path().filename()).string());
+      }
+    }
+  }
+  return dev_paths;
+}
+
 } // namespace uhid

--- a/src/uhid/include/uhid/uhid.hpp
+++ b/src/uhid/include/uhid/uhid.hpp
@@ -1,9 +1,14 @@
 #pragma once
 
+#include <algorithm>
 #include <errno.h>
 #include <fcntl.h>
+#include <filesystem>
+#include <fstream>
 #include <functional>
+#include <iomanip>
 #include <inputtino/result.hpp>
+#include <random>
 #include <iostream>
 #include <linux/uhid.h>
 #include <memory>
@@ -163,6 +168,84 @@ inputtino::Result<Device> Device::create(const DeviceDefinition &definition,
     close(fd);
     return inputtino::Error(res.getErrorMessage());
   }
+}
+
+static std::array<unsigned char, 6> generate_mac_address() {
+  auto rand = std::bind(std::uniform_int_distribution<unsigned char>{0, 0xFF},
+                        std::default_random_engine{std::random_device()()});
+  return {rand(), rand(), rand(), rand(), rand(), rand()};
+}
+
+static std::string mac_to_string(const std::array<unsigned char, 6> &mac) {
+  std::ostringstream ss;
+  for (int i = 0; i < 6; ++i) {
+    if (i > 0) ss << ':';
+    ss << std::hex << std::setfill('0') << std::setw(2) << static_cast<unsigned int>(mac[i]);
+  }
+  return ss.str();
+}
+
+static std::array<unsigned char, 6> mac_from_string(const std::string &str) {
+  std::array<unsigned char, 6> mac = {};
+  std::stringstream ss(str);
+  for (int i = 0; i < 6; ++i) {
+    unsigned int v = 0;
+    ss >> std::hex >> v;
+    mac[i] = static_cast<unsigned char>(v);
+    if (i < 5) ss.ignore(1, ':');
+  }
+  return mac;
+}
+
+/// Case-insensitive MAC string comparison against raw bytes.
+static bool mac_equals(const std::array<unsigned char, 6> &mac, const std::string &str) {
+  return mac == mac_from_string(str);
+}
+
+/**
+ * Find sysfs input nodes for a UHID device by vendor ID and MAC.
+ * Shared by SwitchJoypad and PS5Joypad.
+ */
+static std::vector<std::string> find_uhid_sys_nodes(uint16_t vendor_id,
+                                                     const std::array<unsigned char, 6> &mac) {
+  const std::string base_path = "/sys/devices/virtual/misc/uhid";
+  std::vector<std::string> nodes;
+  if (!std::filesystem::exists(base_path)) {
+    return nodes;
+  }
+
+  std::ostringstream target_id;
+  target_id << std::uppercase << std::hex << std::setfill('0') << std::setw(4)
+            << static_cast<unsigned int>(vendor_id);
+
+  for (const auto &uhid_entry : std::filesystem::directory_iterator{base_path}) {
+    if (!uhid_entry.is_directory()) {
+      continue;
+    }
+    if (uhid_entry.path().filename().string().find(target_id.str()) == std::string::npos) {
+      continue;
+    }
+    auto input_path = uhid_entry.path() / "input";
+    if (!std::filesystem::exists(input_path)) {
+      continue;
+    }
+    for (const auto &dev_entry : std::filesystem::directory_iterator{input_path}) {
+      if (!dev_entry.is_directory()) {
+        continue;
+      }
+      auto uniq_path = dev_entry.path() / "uniq";
+      if (!std::filesystem::exists(uniq_path)) {
+        continue;
+      }
+      std::ifstream uniq_file{uniq_path};
+      std::string uniq_value;
+      std::getline(uniq_file, uniq_value);
+      if (mac_equals(mac, uniq_value)) {
+        nodes.push_back(dev_entry.path().string());
+      }
+    }
+  }
+  return nodes;
 }
 
 } // namespace uhid

--- a/src/uhid/include/uhid/uhid.hpp
+++ b/src/uhid/include/uhid/uhid.hpp
@@ -7,8 +7,8 @@
 #include <fstream>
 #include <functional>
 #include <iomanip>
+#include <inputtino/mac.hpp>
 #include <inputtino/result.hpp>
-#include <random>
 #include <iostream>
 #include <linux/uhid.h>
 #include <memory>
@@ -170,44 +170,11 @@ inputtino::Result<Device> Device::create(const DeviceDefinition &definition,
   }
 }
 
-static std::array<unsigned char, 6> generate_mac_address() {
-  auto rand = std::bind(std::uniform_int_distribution<unsigned char>{0, 0xFF},
-                        std::default_random_engine{std::random_device()()});
-  return {rand(), rand(), rand(), rand(), rand(), rand()};
-}
-
-static std::string mac_to_string(const std::array<unsigned char, 6> &mac) {
-  std::ostringstream ss;
-  for (int i = 0; i < 6; ++i) {
-    if (i > 0) ss << ':';
-    ss << std::hex << std::setfill('0') << std::setw(2) << static_cast<unsigned int>(mac[i]);
-  }
-  return ss.str();
-}
-
-static std::array<unsigned char, 6> mac_from_string(const std::string &str) {
-  std::array<unsigned char, 6> mac = {};
-  std::stringstream ss(str);
-  for (int i = 0; i < 6; ++i) {
-    unsigned int v = 0;
-    ss >> std::hex >> v;
-    mac[i] = static_cast<unsigned char>(v);
-    if (i < 5) ss.ignore(1, ':');
-  }
-  return mac;
-}
-
-/// Case-insensitive MAC string comparison against raw bytes.
-static bool mac_equals(const std::array<unsigned char, 6> &mac, const std::string &str) {
-  return mac == mac_from_string(str);
-}
-
 /**
  * Find sysfs input nodes for a UHID device by vendor ID and MAC.
  * Shared by SwitchJoypad and PS5Joypad.
  */
-static std::vector<std::string> find_uhid_sys_nodes(uint16_t vendor_id,
-                                                     const std::array<unsigned char, 6> &mac) {
+static std::vector<std::string> find_uhid_sys_nodes(uint16_t vendor_id, const inputtino::Mac &mac) {
   const std::string base_path = "/sys/devices/virtual/misc/uhid";
   std::vector<std::string> nodes;
   if (!std::filesystem::exists(base_path)) {
@@ -240,7 +207,7 @@ static std::vector<std::string> find_uhid_sys_nodes(uint16_t vendor_id,
       std::ifstream uniq_file{uniq_path};
       std::string uniq_value;
       std::getline(uniq_file, uniq_value);
-      if (mac_equals(mac, uniq_value)) {
+      if (mac.matches(uniq_value)) {
         nodes.push_back(dev_entry.path().string());
       }
     }

--- a/src/uhid/include/uhid/uhid.hpp
+++ b/src/uhid/include/uhid/uhid.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <inputtino/mac.hpp>
 #include <inputtino/result.hpp>
+#include <iomanip>
 #include <iostream>
 #include <linux/uhid.h>
 #include <memory>
@@ -53,7 +54,7 @@ static inputtino::Result<bool> uhid_write(int fd, const struct uhid_event *ev) {
 class Device {
 private:
   Device(std::shared_ptr<std::thread> ev_thread, std::shared_ptr<ThreadState> state)
-      : ev_thread(std::move(ev_thread)), state(std::move(state)) {};
+      : ev_thread(std::move(ev_thread)), state(std::move(state)){};
   std::shared_ptr<std::thread> ev_thread;
   std::shared_ptr<ThreadState> state;
   std::shared_ptr<std::function<void(const uhid_event &ev, int fd)>> on_event;
@@ -84,7 +85,7 @@ public:
 
   ~Device() {
     if (state) {
-      struct uhid_event ev{};
+      struct uhid_event ev {};
       ev.type = UHID_DESTROY;
       uhid_write(state->fd, &ev);
 
@@ -105,6 +106,8 @@ static void set_c_str(const std::string &str, unsigned char *c_str) {
 
 constexpr int UHID_POLL_TIMEOUT = 500; // ms
 
+// Keep this definition inline because the shared UHID helper is included by
+// multiple controller backends.
 inline inputtino::Result<Device> Device::create(const DeviceDefinition &definition,
                                                  const std::function<void(const uhid_event &ev, int fd)> &on_event) {
 
@@ -143,7 +146,7 @@ inline inputtino::Result<Device> Device::create(const DeviceDefinition &definiti
           break;
         }
         if (pfds[0].revents & POLLIN) {
-          struct uhid_event ev{};
+          struct uhid_event ev {};
           auto ret = read(state->fd, &ev, sizeof(ev));
           if (ret == 0) {
             std::cerr << "Read HUP on uhid-cdev" << std::endl;

--- a/src/uhid/include/uhid/uhid.hpp
+++ b/src/uhid/include/uhid/uhid.hpp
@@ -3,10 +3,7 @@
 #include <algorithm>
 #include <errno.h>
 #include <fcntl.h>
-#include <filesystem>
-#include <fstream>
 #include <functional>
-#include <iomanip>
 #include <inputtino/mac.hpp>
 #include <inputtino/result.hpp>
 #include <iostream>
@@ -108,8 +105,8 @@ static void set_c_str(const std::string &str, unsigned char *c_str) {
 
 constexpr int UHID_POLL_TIMEOUT = 500; // ms
 
-inputtino::Result<Device> Device::create(const DeviceDefinition &definition,
-                                         const std::function<void(const uhid_event &ev, int fd)> &on_event) {
+inline inputtino::Result<Device> Device::create(const DeviceDefinition &definition,
+                                                 const std::function<void(const uhid_event &ev, int fd)> &on_event) {
 
   int fd = open("/dev/uhid", O_RDWR | O_CLOEXEC);
   if (fd < 0) {
@@ -172,47 +169,8 @@ inputtino::Result<Device> Device::create(const DeviceDefinition &definition,
 
 /**
  * Find sysfs input nodes for a UHID device by vendor ID and MAC.
- * Shared by SwitchJoypad and PS5Joypad.
+ * Shared by SwitchJoypad and PS5Joypad. Implemented in uhid.cpp.
  */
-static std::vector<std::string> find_uhid_sys_nodes(uint16_t vendor_id, const inputtino::Mac &mac) {
-  const std::string base_path = "/sys/devices/virtual/misc/uhid";
-  std::vector<std::string> nodes;
-  if (!std::filesystem::exists(base_path)) {
-    return nodes;
-  }
-
-  std::ostringstream target_id;
-  target_id << std::uppercase << std::hex << std::setfill('0') << std::setw(4)
-            << static_cast<unsigned int>(vendor_id);
-
-  for (const auto &uhid_entry : std::filesystem::directory_iterator{base_path}) {
-    if (!uhid_entry.is_directory()) {
-      continue;
-    }
-    if (uhid_entry.path().filename().string().find(target_id.str()) == std::string::npos) {
-      continue;
-    }
-    auto input_path = uhid_entry.path() / "input";
-    if (!std::filesystem::exists(input_path)) {
-      continue;
-    }
-    for (const auto &dev_entry : std::filesystem::directory_iterator{input_path}) {
-      if (!dev_entry.is_directory()) {
-        continue;
-      }
-      auto uniq_path = dev_entry.path() / "uniq";
-      if (!std::filesystem::exists(uniq_path)) {
-        continue;
-      }
-      std::ifstream uniq_file{uniq_path};
-      std::string uniq_value;
-      std::getline(uniq_file, uniq_value);
-      if (mac.matches(uniq_value)) {
-        nodes.push_back(dev_entry.path().string());
-      }
-    }
-  }
-  return nodes;
-}
+std::vector<std::string> find_uhid_sys_nodes(uint16_t vendor_id, const inputtino::Mac &mac);
 
 } // namespace uhid

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -306,20 +306,7 @@ std::vector<std::string> PS5Joypad::get_sys_nodes() const {
 }
 
 std::vector<std::string> PS5Joypad::get_nodes() const {
-  std::vector<std::string> nodes;
-
-  auto sys_nodes = get_sys_nodes();
-  for (const auto dev_entry : sys_nodes) {
-    auto dev_nodes = std::filesystem::directory_iterator{dev_entry};
-    for (auto dev_node : dev_nodes) {
-      if (dev_node.is_directory() && (dev_node.path().filename().string().rfind("event", 0) == 0 ||
-                                      dev_node.path().filename().string().rfind("js", 0) == 0)) {
-        nodes.push_back(("/dev/input/" / dev_node.path().filename()).string());
-      }
-    }
-  }
-
-  return nodes;
+  return uhid::sys_nodes_to_dev_paths(get_sys_nodes());
 }
 
 void PS5Joypad::set_pressed_buttons(unsigned int pressed) {

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -7,7 +7,9 @@
 #include <fstream>
 #include <inputtino/input.hpp>
 #include <iomanip>
+#include <iostream>
 #include <random>
+#include <udev_helpers.hpp>
 #include <uhid/protected_types.hpp>
 #include <uhid/ps5.hpp>
 #include <uhid/uhid.hpp>
@@ -35,7 +37,7 @@ static void send_report(PS5JoypadState &state) {
     state.current_state.sensor_timestamp = htole32(now / 333);
   }
 
-  struct uhid_event ev{};
+  struct uhid_event ev {};
   {
     ev.type = UHID_INPUT2;
 
@@ -70,7 +72,12 @@ static void send_report(PS5JoypadState &state) {
               &ev.u.input2.data[end_of_msg]);
   }
 
-  state.dev->send(ev);
+  // Serialise access to state.dev between the control thread (client
+  // motion/buttons) and the report-pump thread.
+  std::lock_guard<std::mutex> lock(state.mtx);
+  if (state.dev) {
+    state.dev->send(ev);
+  }
 }
 
 static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, int fd) {
@@ -94,8 +101,7 @@ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, 
                 &answer.u.get_report_reply.data[0]);
 
       // Copy MAC address data
-      std::reverse_copy(state->mac.bytes.begin(), state->mac.bytes.end(),
-                        &answer.u.get_report_reply.data[1]);
+      std::reverse_copy(state->mac.bytes.begin(), state->mac.bytes.end(), &answer.u.get_report_reply.data[1]);
 
       answer.u.get_report_reply.size = sizeof(uhid::ps5_pairing_info);
       break;
@@ -215,8 +221,7 @@ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, 
   }
 }
 
-PS5Joypad::PS5Joypad(uint16_t vendor_id, const Mac &mac)
-    : _state(std::make_shared<PS5JoypadState>()) {
+PS5Joypad::PS5Joypad(uint16_t vendor_id, const Mac &mac) : _state(std::make_shared<PS5JoypadState>()) {
   this->_state->mac = mac;
   this->_state->vendor_id = vendor_id;
   // Set touchpad as not pressed
@@ -277,21 +282,25 @@ Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device) {
   if (dev) {
     joypad._state->is_bluetooth = use_bluetooth;
     joypad._state->dev = std::make_shared<uhid::Device>(std::move(*dev));
+    // Keep the resolved definition alongside the device state.
+    joypad._state->def = def;
 
-    // Readers will expect frequent events event if the state hasn't changed
-    joypad._send_input_thread = std::thread([state = joypad._state]() {
-      while (!state->stop_repeat_thread) {
-        send_report(*state);
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      }
-    });
-    joypad._send_input_thread.detach();
+    // Readers will expect frequent events event if the state hasn't changed.
+    // The thread is kept joinable (see the move constructor) so it can be stopped cleanly before the device it
+    // writes to is destroyed on teardown.
+    joypad._send_input_thread = uhid_joypad::start_report_pump<PS5JoypadState>(
+        joypad._state,
+        [](PS5JoypadState &s) { send_report(s); },
+        std::chrono::milliseconds(10));
 
+    // Only return once the kernel (hid-playstation) has exposed the device's
+    // input/hidraw nodes in sysfs, so callers reading get_udev_events()/get_nodes()
+    // right away (e.g. plugging the pad into a container) see a bound device.
+    uhid_joypad::wait_for_sys_nodes([&joypad]() { return joypad.get_sys_nodes(); });
     return joypad;
   }
   return Error(dev.getErrorMessage());
 }
-
 static int scale_value(int input, int input_start, int input_end, int output_start, int output_end) {
   auto slope = 1.0 * (output_end - output_start) / (input_end - input_start);
   return output_start + std::round(slope * (input - input_start));
@@ -430,24 +439,42 @@ static __le16 to_le_signed(float original, float value) {
 }
 
 void PS5Joypad::set_motion(PS5Joypad::MOTION_TYPE type, float x, float y, float z) {
+  // Legacy shim over the generic motion API (single code path). Accel is m/s^2
+  // in both, so it forwards unchanged; gyro arrives here in rad/s but set_gyro()
+  // takes deg/s, so convert rad->deg first. The rad->deg->rad round-trip inside
+  // set_gyro() is exact at the report's int16 quantization, so output is
+  // unchanged for existing callers (e.g. Sunshine).
   switch (type) {
-  case ACCELERATION: {
-    this->_state->current_state.accel[0] = to_le_signed(x, (x * uhid::SDL_STANDARD_GRAVITY_CONST * 100));
-    this->_state->current_state.accel[1] = to_le_signed(y, (y * uhid::SDL_STANDARD_GRAVITY_CONST * 100));
-    this->_state->current_state.accel[2] = to_le_signed(z, (z * uhid::SDL_STANDARD_GRAVITY_CONST * 100));
-
-    send_report(*this->_state);
+  case ACCELERATION:
+    set_accel(x, y, z);
     break;
-  }
   case GYROSCOPE: {
-    this->_state->current_state.gyro[0] = to_le_signed(x, x * uhid::gyro_resolution);
-    this->_state->current_state.gyro[1] = to_le_signed(y, y * uhid::gyro_resolution);
-    this->_state->current_state.gyro[2] = to_le_signed(z, z * uhid::gyro_resolution);
-
-    send_report(*this->_state);
+    constexpr float RAD_TO_DEG = 180.0f / static_cast<float>(M_PI);
+    set_gyro(x * RAD_TO_DEG, y * RAD_TO_DEG, z * RAD_TO_DEG);
     break;
   }
   }
+}
+
+void PS5Joypad::set_gyro(float x, float y, float z) {
+  // Callers pass gyro in deg/s (the SDL / Moonlight convention); the DualSense
+  // HID report is calibrated in rad/s, so the deg->rad conversion lives here
+  // rather than in every caller.
+  constexpr float DEG_TO_RAD = static_cast<float>(M_PI) / 180.0f;
+  this->_state->current_state.gyro[0] = to_le_signed(x, x * DEG_TO_RAD * uhid::gyro_resolution);
+  this->_state->current_state.gyro[1] = to_le_signed(y, y * DEG_TO_RAD * uhid::gyro_resolution);
+  this->_state->current_state.gyro[2] = to_le_signed(z, z * DEG_TO_RAD * uhid::gyro_resolution);
+
+  send_report(*this->_state);
+}
+
+void PS5Joypad::set_accel(float x, float y, float z) {
+  // Accelerometer in m/s^2 (inclusive of gravity); legacy set_motion(ACCELERATION, ...) forwards here.
+  this->_state->current_state.accel[0] = to_le_signed(x, (x * uhid::SDL_STANDARD_GRAVITY_CONST * 100));
+  this->_state->current_state.accel[1] = to_le_signed(y, (y * uhid::SDL_STANDARD_GRAVITY_CONST * 100));
+  this->_state->current_state.accel[2] = to_le_signed(z, (z * uhid::SDL_STANDARD_GRAVITY_CONST * 100));
+
+  send_report(*this->_state);
 }
 
 void PS5Joypad::set_battery(PS5Joypad::BATTERY_STATE state, int percentage) {
@@ -495,6 +522,117 @@ void PS5Joypad::release_finger(int finger_nr) {
     this->_state->current_state.points[finger_nr].contact = 1;
     send_report(*this->_state);
   }
+}
+
+std::vector<Joypad::UdevEvent> PS5Joypad::get_udev_events() const {
+  std::vector<Joypad::UdevEvent> events;
+
+  auto sys_nodes = this->get_sys_nodes();
+  for (const auto &sys_entry : sys_nodes) {
+    for (const auto &sys_node : std::filesystem::directory_iterator{sys_entry}) {
+      auto fname = sys_node.path().filename().string();
+      if (sys_node.is_directory() &&
+          (fname.rfind("event", 0) == 0 || fname.rfind("mouse", 0) == 0 || fname.rfind("js", 0) == 0)) {
+        auto sys_path = sys_node.path().string();
+        sys_path.erase(0, 4); // strip leading /sys
+        auto dev_path = ("/dev/input/" / sys_node.path().filename()).string();
+        auto event = gen_udev_base_event(dev_path, sys_path);
+
+        // The device name tells us whether this node is the touchpad, the motion
+        // sensor or the pad itself.
+        std::ifstream name_file(std::filesystem::path(sys_entry) / "name");
+        std::string name;
+        std::getline(name_file, name);
+        if (name.find("Touchpad") != std::string::npos) {
+          event["ID_INPUT_TOUCHPAD"] = "1";
+          event[".INPUT_CLASS"] = "mouse";
+          event["ID_INPUT_TOUCHPAD_INTEGRATION"] = "internal";
+        } else if (name.find("Motion") != std::string::npos) {
+          event["ID_INPUT_ACCELEROMETER"] = "1";
+          event["ID_INPUT_WIDTH_MM"] = "8";
+          event["ID_INPUT_HEIGHT_MM"] = "8";
+          event["IIO_SENSOR_PROXY_TYPE"] = "input-accel";
+          event["SYSTEMD_WANTS"] = "iio-sensor-proxy.service";
+          event["UNIQ"] = this->get_mac_address();
+        } else {
+          event["ID_INPUT_JOYSTICK"] = "1";
+          event[".INPUT_CLASS"] = "joystick";
+          event["UNIQ"] = this->get_mac_address();
+        }
+        events.emplace_back(event);
+      }
+    }
+  }
+
+  if (!sys_nodes.empty()) {
+    // Add the /dev/hidraw* node (used by Steam to access LED status etc.).
+    auto base_path = std::filesystem::path(sys_nodes[0]).parent_path().parent_path();
+    if (std::filesystem::exists(base_path / "hidraw")) {
+      for (const auto &hidraw_entry : std::filesystem::directory_iterator{base_path / "hidraw"}) {
+        auto dev_path = "/dev/" + hidraw_entry.path().filename().string();
+        auto sys_path = hidraw_entry.path().string();
+        sys_path.erase(0, 4); // strip leading /sys
+        auto event = gen_udev_base_event(dev_path, sys_path);
+        event["SUBSYSTEM"] = "hidraw";
+        events.emplace_back(event);
+      }
+    } else {
+      std::cerr << "inputtino: unable to find HIDRAW nodes for PS5 joypad under " << base_path.string() << std::endl;
+    }
+  }
+
+  return events;
+}
+
+std::vector<Joypad::UdevHwDbEntry> PS5Joypad::get_udev_hw_db_entries() const {
+  std::vector<Joypad::UdevHwDbEntry> result;
+
+  for (const auto &sys_entry : this->get_sys_nodes()) {
+    for (const auto &sys_node : std::filesystem::directory_iterator{sys_entry}) {
+      auto fname = sys_node.path().filename().string();
+      if (sys_node.is_directory() &&
+          (fname.rfind("event", 0) == 0 || fname.rfind("js", 0) == 0 || fname.rfind("mouse", 0) == 0)) {
+        auto dev_path = ("/dev/input/" / sys_node.path().filename()).string();
+        Joypad::UdevHwDbEntry entry;
+        entry.first = gen_udev_hw_db_filename(dev_path);
+
+        std::ifstream name_file(std::filesystem::path(sys_entry) / "name");
+        std::string name;
+        std::getline(name_file, name);
+        if (name.find("Touchpad") != std::string::npos) {
+          entry.second = {"E:ID_INPUT=1",
+                          "E:ID_INPUT_TOUCHPAD=1",
+                          "E:ID_BUS=usb",
+                          "G:seat",
+                          "G:uaccess",
+                          "Q:seat",
+                          "Q:uaccess",
+                          "V:1"};
+        } else if (name.find("Motion") != std::string::npos) {
+          entry.second = {"E:ID_INPUT=1",
+                          "E:ID_INPUT_ACCELEROMETER=1",
+                          "E:ID_BUS=usb",
+                          "G:seat",
+                          "G:uaccess",
+                          "Q:seat",
+                          "Q:uaccess",
+                          "V:1"};
+        } else {
+          entry.second = {"E:ID_INPUT=1",
+                          "E:ID_INPUT_JOYSTICK=1",
+                          "E:ID_BUS=usb",
+                          "G:seat",
+                          "G:uaccess",
+                          "Q:seat",
+                          "Q:uaccess",
+                          "V:1"};
+        }
+        result.emplace_back(entry);
+      }
+    }
+  }
+
+  return result;
 }
 
 } // namespace inputtino

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -228,13 +228,16 @@ PS5Joypad::PS5Joypad(uint16_t vendor_id, const Mac &mac)
 }
 
 PS5Joypad::~PS5Joypad() {
-  if (this->_state && this->_state->dev) {
-    this->_state->stop_repeat_thread = true;
-    if (this->_send_input_thread.joinable()) {
-      this->_send_input_thread.join();
+  if (this->_state) {
+    if (this->_state->dev) {
+      this->_state->stop_repeat_thread = true;
+      if (this->_send_input_thread.joinable()) {
+        this->_send_input_thread.join();
+      }
+      this->_state->dev->stop_thread();
+      this->_state->dev.reset();
     }
-    this->_state->dev->stop_thread();
-    this->_state->dev.reset(); // Will trigger ~Device and ultimately destroy the device
+    Mac::release(this->_state->mac);
   }
 }
 

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -94,7 +94,7 @@ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, 
                 &answer.u.get_report_reply.data[0]);
 
       // Copy MAC address data
-      std::reverse_copy(state->mac.begin(), state->mac.end(),
+      std::reverse_copy(state->mac.bytes.begin(), state->mac.bytes.end(),
                         &answer.u.get_report_reply.data[1]);
 
       answer.u.get_report_reply.size = sizeof(uhid::ps5_pairing_info);
@@ -215,7 +215,7 @@ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, 
   }
 }
 
-PS5Joypad::PS5Joypad(uint16_t vendor_id, std::array<unsigned char, 6> mac)
+PS5Joypad::PS5Joypad(uint16_t vendor_id, const Mac &mac)
     : _state(std::make_shared<PS5JoypadState>()) {
   this->_state->mac = mac;
   this->_state->vendor_id = vendor_id;
@@ -257,10 +257,8 @@ Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device) {
     def.report_description = {&uhid::ps5_rdesc[0], &uhid::ps5_rdesc[0] + sizeof(uhid::ps5_rdesc)};
   }
 
-  auto mac_address = def.uniq.empty()
-      ? uhid::generate_mac_address()
-      : uhid::mac_from_string(def.uniq);
-  auto joypad = PS5Joypad(device.vendor_id, mac_address);
+  auto mac = def.uniq.empty() ? Mac::generate() : Mac::parse(def.uniq);
+  auto joypad = PS5Joypad(device.vendor_id, mac);
 
   if (def.phys.empty()) {
     def.phys = "INPUTTINO_BT_LINK";
@@ -295,7 +293,7 @@ static int scale_value(int input, int input_start, int input_end, int output_sta
 }
 
 std::string PS5Joypad::get_mac_address() const {
-  return uhid::mac_to_string(_state->mac);
+  return _state->mac.to_string();
 }
 
 std::vector<std::string> PS5Joypad::get_sys_nodes() const {

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -237,7 +237,6 @@ PS5Joypad::~PS5Joypad() {
       this->_state->dev->stop_thread();
       this->_state->dev.reset();
     }
-    Mac::release(this->_state->mac);
   }
 }
 
@@ -261,7 +260,10 @@ Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device) {
   }
 
   auto mac = def.uniq.empty() ? Mac::generate() : Mac::parse(def.uniq);
-  auto joypad = PS5Joypad(device.vendor_id, mac);
+  if (!mac) {
+    return Error(mac.getErrorMessage());
+  }
+  auto joypad = PS5Joypad(device.vendor_id, *mac);
 
   if (def.phys.empty()) {
     def.phys = "INPUTTINO_BT_LINK";

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -94,8 +94,7 @@ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, 
                 &answer.u.get_report_reply.data[0]);
 
       // Copy MAC address data
-      std::reverse_copy(&state->mac_address[0],
-                        &state->mac_address[0] + sizeof(state->mac_address),
+      std::reverse_copy(state->mac.begin(), state->mac.end(),
                         &answer.u.get_report_reply.data[1]);
 
       answer.u.get_report_reply.size = sizeof(uhid::ps5_pairing_info);
@@ -216,9 +215,9 @@ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, 
   }
 }
 
-PS5Joypad::PS5Joypad(uint16_t vendor_id, std::array<unsigned char, 6> mac_address)
+PS5Joypad::PS5Joypad(uint16_t vendor_id, std::array<unsigned char, 6> mac)
     : _state(std::make_shared<PS5JoypadState>()) {
-  std::copy(mac_address.begin(), mac_address.end(), this->_state->mac_address);
+  this->_state->mac = mac;
   this->_state->vendor_id = vendor_id;
   // Set touchpad as not pressed
   this->_state->current_state.points[0].contact = 1;
@@ -258,20 +257,9 @@ Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device) {
     def.report_description = {&uhid::ps5_rdesc[0], &uhid::ps5_rdesc[0] + sizeof(uhid::ps5_rdesc)};
   }
 
-  std::array<unsigned char, 6> mac_address = {};
-  if (def.uniq.empty()) {
-    mac_address = generate_mac_address();
-  } else {
-    // Assuming we have in input a MAC address in the format of xx:xx:xx:xx:xx:xx
-    std::stringstream ss(def.uniq);
-    for (int i = 0; i < 6; ++i) {
-      unsigned int value;
-      ss >> std::hex >> value;
-      mac_address[i] = static_cast<unsigned char>(value);
-      if (i < 5)
-        ss.ignore(1, ':');
-    }
-  }
+  auto mac_address = def.uniq.empty()
+      ? uhid::generate_mac_address()
+      : uhid::mac_from_string(def.uniq);
   auto joypad = PS5Joypad(device.vendor_id, mac_address);
 
   if (def.phys.empty()) {
@@ -306,70 +294,12 @@ static int scale_value(int input, int input_start, int input_end, int output_sta
   return output_start + std::round(slope * (input - input_start));
 }
 
-template <typename T> std::string to_hex(T i) {
-  std::stringstream stream;
-  stream << std::hex << std::uppercase << i;
-  return stream.str();
-}
-
 std::string PS5Joypad::get_mac_address() const {
-  std::stringstream stream;
-  stream << std::hex << std::setfill('0') << std::setw(2) << (unsigned int)_state->mac_address[0] << ":" << std::setw(2)
-         << (unsigned int)_state->mac_address[1] << ":" << std::setw(2) << (unsigned int)_state->mac_address[2] << ":"
-         << std::setw(2) << (unsigned int)_state->mac_address[3] << ":" << std::setw(2)
-         << (unsigned int)_state->mac_address[4] << ":" << std::setw(2) << (unsigned int)_state->mac_address[5];
-  return stream.str();
+  return uhid::mac_to_string(_state->mac);
 }
 
-/**
- * The trick here is to match the devices under /sys/devices/virtual/misc/uhid/
- * with the MAC address that we've set for the current device
- *
- * @returns a list of paths to the created input devices ex:
- * /sys/devices/virtual/misc/uhid/0003:054C:0CE6.000D/input/input58/
- */
 std::vector<std::string> PS5Joypad::get_sys_nodes() const {
-  std::vector<std::string> nodes;
-  auto base_path = "/sys/devices/virtual/misc/uhid/";
-  auto target_mac = get_mac_address();
-  if (std::filesystem::exists(base_path)) {
-    auto uhid_entries = std::filesystem::directory_iterator{base_path};
-    for (auto uhid_entry : uhid_entries) {
-      // Here we are looking for a directory that has a name like {BUS_ID}:{VENDOR_ID}:{PRODUCT_ID}.xxxx
-      // (ex: 0003:054C:0CE6.000D)
-      auto uhid_candidate_path = uhid_entry.path().filename().string();
-      auto target_id = to_hex(this->_state->vendor_id);
-      if (uhid_entry.is_directory() && uhid_candidate_path.find(target_id) != std::string::npos) {
-        // Found a match! Let's scan the input devices in that directory
-        if (std::filesystem::exists(uhid_entry.path() / "input")) {
-          // ex: /sys/devices/virtual/misc/uhid/0003:054C:0CE6.000D/input/
-          auto dev_entries = std::filesystem::directory_iterator{uhid_entry.path() / "input"};
-          for (auto dev_entry : dev_entries) {
-            // Here we only have a match if the "uniq" file inside contains the same MAC address that we've set
-            if (dev_entry.is_directory()) {
-              // ex: /sys/devices/virtual/misc/uhid/0003:054C:0CE6.000D/input/input58/uniq
-              auto dev_uniq_path = dev_entry.path() / "uniq";
-              if (std::filesystem::exists(dev_uniq_path)) {
-                std::ifstream dev_uniq_file{dev_uniq_path};
-                std::string line;
-                std::getline(dev_uniq_file, line);
-                if (line == target_mac) {
-                  nodes.push_back(dev_entry.path().string());
-                }
-              } else {
-                fprintf(stderr, "Unable to get joypad nodes, path %s does not exist\n", dev_uniq_path.string().c_str());
-              }
-            }
-          }
-        } else {
-          fprintf(stderr, "Unable to get joypad nodes, path %s does not exist\n", uhid_entry.path().string().c_str());
-        }
-      }
-    }
-  } else {
-    fprintf(stderr, "Unable to get joypad nodes, path %s does not exist\n", base_path);
-  }
-  return nodes;
+  return uhid::find_uhid_sys_nodes(_state->vendor_id, _state->mac);
 }
 
 std::vector<std::string> PS5Joypad::get_nodes() const {

--- a/src/uhid/joypad_switch.cpp
+++ b/src/uhid/joypad_switch.cpp
@@ -337,6 +337,11 @@ Result<SwitchJoypad> SwitchJoypad::create(const DeviceDefinition &device) {
   auto joypad = SwitchJoypad(*mac);
   joypad._state->vendor_id = device.vendor_id;
   joypad._state->product_id = device.product_id;
+  if (device.product_id == uhid::JOYCON_PID_LEFT) {
+    joypad._state->controller_type = uhid::JOYCON_CTLR_TYPE_JCL;
+  } else if (device.product_id == uhid::JOYCON_PID_RIGHT) {
+    joypad._state->controller_type = uhid::JOYCON_CTLR_TYPE_JCR;
+  }
 
   auto def = uhid::DeviceDefinition{
       .name = device.name,
@@ -373,6 +378,10 @@ Result<SwitchJoypad> SwitchJoypad::create(const DeviceDefinition &device) {
 }
 std::string SwitchJoypad::get_mac_address() const {
   return _state->mac.to_string();
+}
+
+uint16_t SwitchJoypad::get_product_id() const {
+  return _state->product_id;
 }
 
 std::vector<std::string> SwitchJoypad::get_sys_nodes() const {
@@ -476,9 +485,11 @@ static void apply_switch_imu(SwitchJoypadState &state, bool is_accel, float x, f
   // Remap from SDL coordinate frame to hid-nintendo's native frame.
   //   SDL_X = -kernel_Y,  SDL_Y = kernel_Z,  SDL_Z = -kernel_X
   // Invert:  kernel_X = -SDL_Z,  kernel_Y = -SDL_X,  kernel_Z = SDL_Y
+  // Right Joy-Con: hid-nintendo negates Y/Z, so counter-negate.
+  bool is_right_joycon = state.product_id == uhid::JOYCON_PID_RIGHT;
   float nx = -z;
-  float ny = -x;
-  float nz = y;
+  float ny = is_right_joycon ? x : -x;
+  float nz = is_right_joycon ? -y : y;
 
   int16_t sx = 0;
   int16_t sy = 0;

--- a/src/uhid/joypad_switch.cpp
+++ b/src/uhid/joypad_switch.cpp
@@ -1,0 +1,733 @@
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <chrono>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <inputtino/input.hpp>
+#include <mutex>
+#include <udev_helpers.hpp>
+#include <uhid/protected_types.hpp>
+#include <uhid/switch.hpp>
+#include <uhid/uhid.hpp>
+
+namespace inputtino {
+
+namespace {
+
+// Real Bluetooth Pro Controller 0x30 reports on the host consistently show:
+// - bat_con = 0x60
+// - button_status = 00 80 00 at idle
+//
+// Mirror that steady-state shape as closely as possible so hid-nintendo sees
+// reports that look like a real controller rather than a synthetic
+// "full+charging" device with an all-zero button prefix.
+constexpr uint8_t SWITCH_BATTERY_HIGH_BT = 0x60;
+constexpr uint8_t SWITCH_BUTTON_STATUS1_BASE = 0x80;
+
+// Map signed 16-bit stick axis to 12-bit Switch range [0, 4095] centered at 2048.
+int scale_axis(short value) {
+  auto slope = static_cast<double>(uhid::SWITCH_AXIS_MAX) / 65535.0;
+  return static_cast<int>(std::round(slope * (static_cast<int>(value) + 32768)));
+}
+
+// Pack two 12-bit values into 3 bytes: X in bits 0-11, Y in bits 12-23.
+void pack_12bit_pair(uint8_t *out, uint16_t x, uint16_t y) {
+  out[0] = static_cast<uint8_t>(x & 0xFF);
+  out[1] = static_cast<uint8_t>(((x >> 8) & 0x0F) | ((y & 0x0F) << 4));
+  out[2] = static_cast<uint8_t>((y >> 4) & 0xFF);
+}
+
+// Left stick factory calibration at 0x603D: hid-nintendo parses as
+// (max_above, center, min_below).
+void fill_left_stick_calibration(uint8_t *data) {
+  pack_12bit_pair(data + 0, 2047, 2047); // max_above
+  pack_12bit_pair(data + 3, 2048, 2048); // center
+  pack_12bit_pair(data + 6, 2048, 2048); // min_below
+}
+
+// Right stick factory calibration at 0x6046: hid-nintendo parses as
+// (center, min_below, max_above) — different order from left stick.
+void fill_right_stick_calibration(uint8_t *data) {
+  pack_12bit_pair(data + 0, 2048, 2048); // center
+  pack_12bit_pair(data + 3, 2048, 2048); // min_below
+  pack_12bit_pair(data + 6, 2047, 2047); // max_above
+}
+
+// IMU factory calibration layout (24 bytes, matching hid-nintendo's parsing):
+//   bytes  0-5:  accel offset  (3x int16 LE)
+//   bytes  6-11: accel scale   (3x int16 LE)
+//   bytes 12-17: gyro offset   (3x int16 LE)
+//   bytes 18-23: gyro scale    (3x int16 LE)
+// The kernel computes divisor = scale - offset per axis.
+void fill_imu_calibration(uint8_t *data) {
+  auto write_le16 = [&](int index, int16_t value) {
+    data[index] = static_cast<uint8_t>(value & 0xFF);
+    data[index + 1] = static_cast<uint8_t>((value >> 8) & 0xFF);
+  };
+
+  for (int i = 0; i < 3; ++i) {
+    write_le16(i * 2, uhid::SWITCH_IMU_ACCEL_OFFSET);
+    write_le16(6 + i * 2, uhid::SWITCH_IMU_ACCEL_SCALE_CAL);
+    write_le16(12 + i * 2, uhid::SWITCH_IMU_GYRO_OFFSET);
+    write_le16(18 + i * 2, uhid::SWITCH_IMU_GYRO_SCALE_CAL);
+  }
+}
+
+int decode_rumble_high_amplitude(uint8_t encoded) {
+  // encoded ∈ [0x00, 0xC8] maps linearly to amplitude ∈ [0, 65535]
+  return static_cast<int>(std::lround(encoded * (65535.0 / 0xC8)));
+}
+
+int decode_rumble_low_amplitude(uint16_t encoded) {
+  // Bits 7:0 range from 0x40 to 0x72 (→ base index 0..50); bit 15 is a half-step flag.
+  // Combined index ∈ [0, 100] maps linearly to amplitude ∈ [0, 65535].
+  int index = (static_cast<int>(encoded & 0xFF) - 0x40) * 2 + ((encoded >> 15) & 1);
+  return static_cast<int>(std::lround(std::clamp(index, 0, 100) * (65535.0 / 100)));
+}
+
+std::pair<int, int> decode_rumble_block(const uhid::switch_rumble_data &rumble) {
+  auto high_amplitude = decode_rumble_high_amplitude(rumble.amp_high);
+  auto low_amplitude =
+      decode_rumble_low_amplitude(static_cast<uint16_t>((rumble.freq_low & 0x80) << 8) | rumble.amp_low);
+  return {low_amplitude, high_amplitude};
+}
+
+void fill_reply_prefix(SwitchJoypadState &state, uhid::switch_standard_input_prefix &prefix, uint8_t report_id) {
+  prefix.report_id = report_id;
+  prefix.timer = state.timer++;
+  prefix.bat_con = SWITCH_BATTERY_HIGH_BT;
+  prefix.vibrator_input = 0;
+  std::copy(std::begin(state.buttons), std::end(state.buttons), std::begin(prefix.button_status));
+  pack_12bit_pair(prefix.left_stick, state.lx, state.ly);
+  pack_12bit_pair(prefix.right_stick, state.rx, state.ry);
+}
+
+void send_report(SwitchJoypadState &state) {
+  std::lock_guard<std::mutex> lock(state.mtx);
+
+  if (state.report_mode != uhid::SWITCH_REPORT_MODE_STANDARD_FULL) {
+    return;
+  }
+
+  uhid::switch_input_report report{};
+  fill_reply_prefix(state, report.prefix, uhid::SWITCH_INPUT_REPORT_STANDARD_FULL);
+  std::copy(std::begin(state.imu), std::end(state.imu), std::begin(report.imu));
+
+  struct uhid_event ev {};
+  ev.type = UHID_INPUT2;
+  std::copy(reinterpret_cast<unsigned char *>(&report),
+            reinterpret_cast<unsigned char *>(&report) + sizeof(report),
+            &ev.u.input2.data[0]);
+  ev.u.input2.size = sizeof(report);
+  if (state.dev) {
+    state.dev->send(ev);
+  }
+}
+
+void send_subcmd_reply(
+    SwitchJoypadState &state, uint8_t ack, uint8_t subcmd_id, const uint8_t *payload, size_t payload_size) {
+  std::lock_guard<std::mutex> lock(state.mtx);
+
+  uhid::switch_subcmd_reply_report report{};
+  fill_reply_prefix(state, report.prefix, uhid::SWITCH_INPUT_REPORT_SUBCOMMAND_REPLY);
+  report.ack = ack;
+  report.subcmd_id = subcmd_id;
+  if (payload && payload_size > 0) {
+    std::copy(payload, payload + std::min(payload_size, sizeof(report.data)), std::begin(report.data));
+  }
+
+  struct uhid_event ev {};
+  ev.type = UHID_INPUT2;
+  std::copy(reinterpret_cast<unsigned char *>(&report),
+            reinterpret_cast<unsigned char *>(&report) + sizeof(report),
+            &ev.u.input2.data[0]);
+  ev.u.input2.size = sizeof(report);
+  if (state.dev) {
+    state.dev->send(ev);
+  }
+}
+
+void handle_spi_flash_read(SwitchJoypadState &state, const uint8_t *request_data) {
+  uint32_t address = static_cast<uint32_t>(request_data[0]) | (static_cast<uint32_t>(request_data[1]) << 8) |
+                     (static_cast<uint32_t>(request_data[2]) << 16) | (static_cast<uint32_t>(request_data[3]) << 24);
+  uint8_t size = request_data[4];
+
+  uint8_t payload[35] = {};
+  payload[0] = request_data[0];
+  payload[1] = request_data[1];
+  payload[2] = request_data[2];
+  payload[3] = request_data[3];
+  payload[4] = size;
+
+  switch (address) {
+  case uhid::JC_CAL_USR_LEFT_MAGIC_ADDR:
+  case uhid::JC_CAL_USR_RIGHT_MAGIC_ADDR:
+  case uhid::JC_IMU_CAL_USR_MAGIC_ADDR:
+    payload[5] = 0x00;
+    payload[6] = 0x00;
+    break;
+  case uhid::JC_CAL_FCT_DATA_LEFT_ADDR:
+    fill_left_stick_calibration(&payload[5]);
+    // SDL reads both sticks in one 18-byte SPI read from 0x603D.
+    // The kernel reads them separately (9 bytes each from 0x603D and 0x6046).
+    // Fill the right stick data at offset +9 so both paths work.
+    if (size >= 18) {
+      fill_right_stick_calibration(&payload[5 + 9]);
+    }
+    break;
+  case uhid::JC_CAL_FCT_DATA_RIGHT_ADDR:
+    fill_right_stick_calibration(&payload[5]);
+    break;
+  case uhid::JC_IMU_CAL_FCT_DATA_ADDR:
+    fill_imu_calibration(&payload[5]);
+    break;
+  default:
+    break;
+  }
+
+  send_subcmd_reply(state,
+                    uhid::SWITCH_ACK_SPI_FLASH_READ,
+                    uhid::SWITCH_SUBCMD_SPI_FLASH_READ,
+                    payload,
+                    sizeof(payload));
+}
+
+void handle_output_report(std::shared_ptr<SwitchJoypadState> state, const uint8_t *data, size_t size) {
+  if (!data || size == 0) {
+    return;
+  }
+
+  auto report_id = data[0];
+  if (report_id == uhid::SWITCH_OUTPUT_REPORT_RUMBLE_ONLY) {
+    if (size >= sizeof(uhid::switch_output_report_rumble_only) && state->on_rumble) {
+      const auto *report = reinterpret_cast<const uhid::switch_output_report_rumble_only *>(data);
+      auto [low_left, high_left] = decode_rumble_block(report->left);
+      auto [low_right, high_right] = decode_rumble_block(report->right);
+      (*state->on_rumble)(std::max(low_left, low_right), std::max(high_left, high_right));
+    }
+    return;
+  }
+  if (report_id != uhid::SWITCH_OUTPUT_REPORT_RUMBLE_AND_SUBCOMMAND) {
+    return;
+  }
+  if (size < sizeof(uhid::switch_output_report_rumble_subcmd)) {
+    return;
+  }
+
+  const auto *report = reinterpret_cast<const uhid::switch_output_report_rumble_subcmd *>(data);
+  auto subcmd_id = report->subcmd_id;
+  const uint8_t *subcmd_data = data + sizeof(uhid::switch_output_report_rumble_subcmd);
+
+  switch (subcmd_id) {
+  case uhid::SWITCH_SUBCMD_REQ_DEV_INFO: {
+    uint8_t payload[35] = {};
+    payload[0] = 0x04;
+    payload[1] = 0x33;
+    payload[2] = state->controller_type;
+    payload[3] = 0x02;
+    std::copy(state->mac.bytes.begin(), state->mac.bytes.end(), &payload[4]);
+    send_subcmd_reply(*state, uhid::SWITCH_ACK_DEV_INFO, subcmd_id, payload, sizeof(payload));
+    break;
+  }
+  case uhid::SWITCH_SUBCMD_SET_INPUT_REPORT_MODE: {
+    std::lock_guard<std::mutex> lock(state->mtx);
+    state->report_mode = subcmd_data[0];
+  }
+    send_subcmd_reply(*state, uhid::SWITCH_ACK, subcmd_id, nullptr, 0);
+    break;
+  case uhid::SWITCH_SUBCMD_ENABLE_IMU: {
+    std::lock_guard<std::mutex> lock(state->mtx);
+    state->imu_enabled = subcmd_data[0] != 0;
+  }
+    send_subcmd_reply(*state, uhid::SWITCH_ACK, subcmd_id, nullptr, 0);
+    break;
+  case uhid::SWITCH_SUBCMD_ENABLE_VIBRATION: {
+    std::lock_guard<std::mutex> lock(state->mtx);
+    state->vibration_enabled = subcmd_data[0] != 0;
+  }
+    send_subcmd_reply(*state, uhid::SWITCH_ACK, subcmd_id, nullptr, 0);
+    break;
+  case uhid::SWITCH_SUBCMD_SPI_FLASH_READ:
+    handle_spi_flash_read(*state, subcmd_data);
+    break;
+  case uhid::SWITCH_SUBCMD_SET_PLAYER_LIGHTS:
+    send_subcmd_reply(*state, uhid::SWITCH_ACK, subcmd_id, nullptr, 0);
+    break;
+  case uhid::SWITCH_SUBCMD_GET_PLAYER_LIGHTS: {
+    uint8_t payload[35] = {};
+    payload[0] = 0x01;
+    send_subcmd_reply(*state, uhid::SWITCH_ACK, subcmd_id, payload, sizeof(payload));
+    break;
+  }
+  case uhid::SWITCH_SUBCMD_SET_HOME_LIGHT:
+    send_subcmd_reply(*state, uhid::SWITCH_ACK, subcmd_id, nullptr, 0);
+    break;
+  default:
+    send_subcmd_reply(*state, uhid::SWITCH_ACK, subcmd_id, nullptr, 0);
+    break;
+  }
+
+  // Subcmd packets also carry rumble data; reset after processing the subcmd
+  // so the rumble effect doesn't persist beyond the command exchange.
+  if (state->on_rumble) {
+    (*state->on_rumble)(0, 0);
+  }
+}
+
+void on_uhid_event(std::shared_ptr<SwitchJoypadState> state, uhid_event ev, int fd) {
+  switch (ev.type) {
+  case UHID_OUTPUT:
+    handle_output_report(state, ev.u.output.data, ev.u.output.size);
+    break;
+  case UHID_GET_REPORT: {
+    uhid_event answer{};
+    answer.type = UHID_GET_REPORT_REPLY;
+    answer.u.get_report_reply.id = ev.u.get_report.id;
+    answer.u.get_report_reply.err = 0;
+    answer.u.get_report_reply.size = 0;
+    auto res = uhid::uhid_write(fd, &answer);
+    (void)res;
+    break;
+  }
+  case UHID_SET_REPORT: {
+    if (ev.u.set_report.rtype == UHID_OUTPUT_REPORT) {
+      handle_output_report(state, ev.u.set_report.data, ev.u.set_report.size);
+    }
+
+    uhid_event answer{};
+    answer.type = UHID_SET_REPORT_REPLY;
+    answer.u.set_report_reply.id = ev.u.set_report.id;
+    answer.u.set_report_reply.err = 0;
+    auto res = uhid::uhid_write(fd, &answer);
+    (void)res;
+    break;
+  }
+  default:
+    break;
+  }
+}
+
+} // namespace
+
+SwitchJoypad::SwitchJoypad(const Mac &mac) : _state(std::make_shared<SwitchJoypadState>()) {
+  this->_state->mac = mac;
+  this->_state->buttons[1] = SWITCH_BUTTON_STATUS1_BASE;
+}
+
+SwitchJoypad::~SwitchJoypad() {
+  if (this->_state) {
+    if (this->_state->dev) {
+      this->_state->stop_repeat_thread = true;
+      if (this->_send_input_thread.joinable()) {
+        this->_send_input_thread.join();
+      }
+      this->_state->dev->stop_thread();
+      this->_state->dev.reset();
+    }
+  }
+}
+
+Result<SwitchJoypad> SwitchJoypad::create(const DeviceDefinition &device) {
+  auto mac = device.device_uniq.empty() ? Mac::generate() : Mac::parse(device.device_uniq);
+  if (!mac) {
+    return Error(mac.getErrorMessage());
+  }
+  auto joypad = SwitchJoypad(*mac);
+  joypad._state->vendor_id = device.vendor_id;
+  joypad._state->product_id = device.product_id;
+
+  auto def = uhid::DeviceDefinition{
+      .name = device.name,
+      .phys = device.device_phys.empty() ? "bluetooth" : device.device_phys,
+      .uniq = joypad._state->mac.to_string(),
+      .bus = BUS_BLUETOOTH,
+      .vendor = static_cast<uint32_t>(device.vendor_id),
+      .product = static_cast<uint32_t>(device.product_id),
+      .version = static_cast<uint32_t>(device.version),
+      .country = 0,
+      .report_description = {&uhid::switch_rdesc_bt[0], &uhid::switch_rdesc_bt[0] + sizeof(uhid::switch_rdesc_bt)}};
+
+  auto dev =
+      uhid::Device::create(def, [state = joypad._state](uhid_event ev, int fd) { on_uhid_event(state, ev, fd); });
+  if (!dev) {
+    return Error(dev.getErrorMessage());
+  }
+
+  joypad._state->dev = std::make_shared<uhid::Device>(std::move(*dev));
+  // Stash the (fully resolved) definition so the device can be re-created in place later — same MAC/uniq, so
+  // get_sys_nodes() still matches and lobby hand-off keeps its /dev/input/* layout.
+  joypad._state->def = def;
+  // A real Pro Controller sends 0x30 reports at ~66Hz (~15ms interval).
+  // Mirror that cadence so hid-nintendo's "dropped IMU reports" detection
+  // doesn't flag a gap.
+  joypad._send_input_thread = uhid_joypad::start_report_pump<SwitchJoypadState>(
+      joypad._state,
+      [](SwitchJoypadState &s) { send_report(s); },
+      std::chrono::milliseconds(15));
+
+  // Only return once the kernel has exposed the device's input nodes in sysfs.
+  uhid_joypad::wait_for_sys_nodes([&joypad]() { return joypad.get_sys_nodes(); });
+  return joypad;
+}
+std::string SwitchJoypad::get_mac_address() const {
+  return _state->mac.to_string();
+}
+
+std::vector<std::string> SwitchJoypad::get_sys_nodes() const {
+  return uhid::find_uhid_sys_nodes(_state->vendor_id, _state->mac);
+}
+
+std::vector<std::string> SwitchJoypad::get_nodes() const {
+  return uhid::sys_nodes_to_dev_paths(get_sys_nodes());
+}
+
+void SwitchJoypad::set_pressed_buttons(unsigned int pressed) {
+  {
+    std::lock_guard<std::mutex> lock(this->_state->mtx);
+    auto &buttons = this->_state->buttons;
+    buttons[0] = 0;
+    buttons[1] = SWITCH_BUTTON_STATUS1_BASE;
+    buttons[2] = 0;
+
+    // Positional remap so the Joypad API (Xbox naming) stays consistent
+    // across backends. Physically, Switch Y is where Xbox X sits (left),
+    // Switch X is where Xbox Y sits (top), Switch B is bottom, Switch A is
+    // right — so Xbox A→SwitchB, Xbox B→SwitchA, Xbox X→SwitchY,
+    // Xbox Y→SwitchX. SDL's gamepad DB then round-trips to the right
+    // SDL_CONTROLLER_BUTTON_*.
+    if (X & pressed)
+      buttons[0] |= 0x01; // Switch Y slot (west / left)
+    if (Y & pressed)
+      buttons[0] |= 0x02; // Switch X slot (north / top)
+    if (A & pressed)
+      buttons[0] |= 0x04; // Switch B slot (south / bottom)
+    if (B & pressed)
+      buttons[0] |= 0x08; // Switch A slot (east / right)
+    if (RIGHT_BUTTON & pressed)
+      buttons[0] |= 0x40;
+
+    if (BACK & pressed)
+      buttons[1] |= 0x01;
+    if (START & pressed)
+      buttons[1] |= 0x02;
+    if (RIGHT_STICK & pressed)
+      buttons[1] |= 0x04;
+    if (LEFT_STICK & pressed)
+      buttons[1] |= 0x08;
+    if (HOME & pressed)
+      buttons[1] |= 0x10;
+    if (MISC_FLAG & pressed)
+      buttons[1] |= 0x20;
+
+    if (DPAD_DOWN & pressed)
+      buttons[2] |= 0x01;
+    if (DPAD_UP & pressed)
+      buttons[2] |= 0x02;
+    if (DPAD_RIGHT & pressed)
+      buttons[2] |= 0x04;
+    if (DPAD_LEFT & pressed)
+      buttons[2] |= 0x08;
+    if (LEFT_BUTTON & pressed)
+      buttons[2] |= 0x40;
+  }
+  send_report(*this->_state);
+}
+
+void SwitchJoypad::set_triggers(int16_t left, int16_t right) {
+  {
+    std::lock_guard<std::mutex> lock(this->_state->mtx);
+    auto &buttons = this->_state->buttons;
+    if (left > 0) {
+      buttons[2] |= 0x80;
+    } else {
+      buttons[2] &= ~0x80;
+    }
+    if (right > 0) {
+      buttons[0] |= 0x80;
+    } else {
+      buttons[0] &= ~0x80;
+    }
+  }
+  send_report(*this->_state);
+}
+
+void SwitchJoypad::set_stick(Joypad::STICK_POSITION stick_type, short x, short y) {
+  auto scaled_x = static_cast<uint16_t>(scale_axis(x));
+  auto scaled_y = static_cast<uint16_t>(scale_axis(y));
+  {
+    std::lock_guard<std::mutex> lock(this->_state->mtx);
+    if (stick_type == LS) {
+      this->_state->lx = scaled_x;
+      this->_state->ly = scaled_y;
+    } else {
+      this->_state->rx = scaled_x;
+      this->_state->ry = scaled_y;
+    }
+  }
+  send_report(*this->_state);
+}
+
+// Switch IMU sample write. is_accel selects accelerometer (m/s^2) vs gyroscope
+// (deg/s); both take the SDL/Moonlight convention — the Switch path needs no unit
+// fix (unlike PS5's rad/s gyro), only the SDL->hid-nintendo coordinate remap.
+static void apply_switch_imu(SwitchJoypadState &state, bool is_accel, float x, float y, float z) {
+  // Remap from SDL coordinate frame to hid-nintendo's native frame.
+  //   SDL_X = -kernel_Y,  SDL_Y = kernel_Z,  SDL_Z = -kernel_X
+  // Invert:  kernel_X = -SDL_Z,  kernel_Y = -SDL_X,  kernel_Z = SDL_Y
+  float nx = -z;
+  float ny = -x;
+  float nz = y;
+
+  int16_t sx = 0;
+  int16_t sy = 0;
+  int16_t sz = 0;
+
+  if (is_accel) {
+    sx = static_cast<int16_t>(
+        std::clamp(std::lround((nx / uhid::SWITCH_STANDARD_GRAVITY_CONST) * uhid::SWITCH_ACCEL_SCALE),
+                   static_cast<long>(INT16_MIN),
+                   static_cast<long>(INT16_MAX)));
+    sy = static_cast<int16_t>(
+        std::clamp(std::lround((ny / uhid::SWITCH_STANDARD_GRAVITY_CONST) * uhid::SWITCH_ACCEL_SCALE),
+                   static_cast<long>(INT16_MIN),
+                   static_cast<long>(INT16_MAX)));
+    sz = static_cast<int16_t>(
+        std::clamp(std::lround((nz / uhid::SWITCH_STANDARD_GRAVITY_CONST) * uhid::SWITCH_ACCEL_SCALE),
+                   static_cast<long>(INT16_MIN),
+                   static_cast<long>(INT16_MAX)));
+  } else {
+    sx = static_cast<int16_t>(std::clamp(std::lround(nx * uhid::SWITCH_GYRO_SCALE),
+                                         static_cast<long>(INT16_MIN),
+                                         static_cast<long>(INT16_MAX)));
+    sy = static_cast<int16_t>(std::clamp(std::lround(ny * uhid::SWITCH_GYRO_SCALE),
+                                         static_cast<long>(INT16_MIN),
+                                         static_cast<long>(INT16_MAX)));
+    sz = static_cast<int16_t>(std::clamp(std::lround(nz * uhid::SWITCH_GYRO_SCALE),
+                                         static_cast<long>(INT16_MIN),
+                                         static_cast<long>(INT16_MAX)));
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(state.mtx);
+    if (!state.imu_enabled) {
+      return;
+    }
+    for (auto &sample : state.imu) {
+      if (is_accel) {
+        sample.accel[0] = sx;
+        sample.accel[1] = sy;
+        sample.accel[2] = sz;
+      } else {
+        sample.gyro[0] = sx;
+        sample.gyro[1] = sy;
+        sample.gyro[2] = sz;
+      }
+    }
+  }
+  send_report(state);
+}
+
+void SwitchJoypad::set_gyro(float x, float y, float z) {
+  apply_switch_imu(*this->_state, /* is_accel */ false, x, y, z);
+}
+
+void SwitchJoypad::set_accel(float x, float y, float z) {
+  apply_switch_imu(*this->_state, /* is_accel */ true, x, y, z);
+}
+
+void SwitchJoypad::set_on_rumble(const std::function<void(int low_freq, int high_freq)> &callback) {
+  this->_state->on_rumble = callback;
+}
+
+namespace {
+
+constexpr auto SWITCH_VENDOR_ID = "057e";
+constexpr auto SWITCH_PRODUCT_ID = "2009";
+
+std::string uppercase_ascii(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::toupper(ch));
+  });
+  return value;
+}
+
+std::map<std::string, std::string> read_uevent_properties(const std::filesystem::path &uevent_path) {
+  std::map<std::string, std::string> props;
+  std::ifstream uevent_file(uevent_path);
+  std::string line;
+  while (std::getline(uevent_file, line)) {
+    if (auto split = line.find('='); split != std::string::npos) {
+      auto value = line.substr(split + 1);
+      if (value.size() >= 2 && value.front() == '"' && value.back() == '"') {
+        value = value.substr(1, value.size() - 2);
+      }
+      props.emplace(line.substr(0, split), value);
+    }
+  }
+  return props;
+}
+
+std::map<std::string, std::string> switch_input_identity(const std::filesystem::path &sys_entry,
+                                                         const std::string &fallback_uniq) {
+  auto props = read_uevent_properties(sys_entry / "uevent");
+  const auto uniq = uppercase_ascii(props.count("UNIQ") ? props.at("UNIQ") : fallback_uniq);
+  return {
+      {"UNIQ", uniq},
+      {"HID_UNIQ", uniq},
+      {"PHYS", props.count("PHYS") ? props.at("PHYS") : "bluetooth"},
+      {"MODALIAS", props.count("MODALIAS") ? props.at("MODALIAS") : "hid:b0005g0001v0000057Ep00002009"},
+  };
+}
+
+std::map<std::string, std::string> switch_hid_identity(const std::filesystem::path &base_path,
+                                                       const std::string &fallback_uniq) {
+  auto props = read_uevent_properties(base_path / "uevent");
+  const auto uniq = uppercase_ascii(props.count("HID_UNIQ") ? props.at("HID_UNIQ") : fallback_uniq);
+  return {
+      {"HID_UNIQ", uniq},
+      {"HID_PHYS", props.count("HID_PHYS") ? props.at("HID_PHYS") : "bluetooth"},
+      {"MODALIAS", props.count("MODALIAS") ? props.at("MODALIAS") : "hid:b0005g0001v0000057Ep00002009"},
+  };
+}
+
+// Stamp the Switch Pro Bluetooth HID identity onto a udev event map.
+void append_switch_identity(std::map<std::string, std::string> &event,
+                            const std::map<std::string, std::string> &identity) {
+  for (const auto &[key, value] : identity) {
+    if (!value.empty()) {
+      event[key] = value;
+    }
+  }
+  event["ID_BUS"] = "bluetooth";
+  event["HID_NAME"] = "Pro Controller";
+  event["HID_ID"] = "0005:0000057E:00002009";
+  event["ID_VENDOR_ID"] = SWITCH_VENDOR_ID;
+  event["ID_MODEL_ID"] = SWITCH_PRODUCT_ID;
+}
+
+// Same identity, as hwdb "E:KEY=VALUE" rows appended to an entry.
+void append_switch_identity(std::vector<std::string> &entry, const std::map<std::string, std::string> &identity) {
+  std::vector<std::string> rows = {
+      "E:ID_BUS=bluetooth",
+      "E:HID_NAME=Pro Controller",
+      "E:HID_ID=0005:0000057E:00002009",
+      "E:ID_VENDOR_ID=057e",
+      "E:ID_MODEL_ID=2009",
+      "E:ID_VENDOR=Nintendo",
+      "E:ID_MODEL=Pro_Controller",
+      "E:ID_SERIAL=Nintendo_Pro_Controller",
+  };
+  for (const auto &[key, value] : identity) {
+    if (!value.empty()) {
+      rows.push_back("E:" + key + "=" + value);
+    }
+  }
+  entry.insert(entry.end(), rows.begin(), rows.end());
+}
+
+} // namespace
+
+std::vector<Joypad::UdevEvent> SwitchJoypad::get_udev_events() const {
+  std::vector<Joypad::UdevEvent> events;
+  const auto uniq = this->get_mac_address();
+
+  auto sys_nodes = this->get_sys_nodes();
+  for (const auto &sys_entry : sys_nodes) {
+    for (const auto &sys_node : std::filesystem::directory_iterator{sys_entry}) {
+      if (!sys_node.is_directory() || sys_node.path().filename().string().rfind("event", 0) != 0) {
+        continue;
+      }
+
+      auto sys_path = sys_node.path().string();
+      sys_path.erase(0, 4); // strip leading /sys
+      auto dev_path = ("/dev/input/" / sys_node.path().filename()).string();
+      auto event = gen_udev_base_event(dev_path, sys_path);
+      auto identity = switch_input_identity(sys_entry, uniq);
+
+      std::ifstream name_file(std::filesystem::path(sys_entry) / "name");
+      std::string name;
+      std::getline(name_file, name);
+
+      if (name.find("Motion") != std::string::npos || name.find("IMU") != std::string::npos) {
+        event["ID_INPUT_ACCELEROMETER"] = "1";
+        event["ID_INPUT_WIDTH_MM"] = "8";
+        event["ID_INPUT_HEIGHT_MM"] = "8";
+        event["IIO_SENSOR_PROXY_TYPE"] = "input-accel";
+        event["SYSTEMD_WANTS"] = "iio-sensor-proxy.service";
+        event["UNIQ"] = uniq;
+      } else {
+        event["ID_INPUT_JOYSTICK"] = "1";
+        event[".INPUT_CLASS"] = "joystick";
+      }
+      append_switch_identity(event, identity);
+      events.emplace_back(event);
+    }
+  }
+
+  if (!sys_nodes.empty()) {
+    auto base_path = std::filesystem::path(sys_nodes[0]).parent_path().parent_path();
+    if (std::filesystem::exists(base_path / "hidraw")) {
+      for (const auto &hidraw_entry : std::filesystem::directory_iterator{base_path / "hidraw"}) {
+        auto dev_path = "/dev/" + hidraw_entry.path().filename().string();
+        auto sys_path = hidraw_entry.path().string();
+        sys_path.erase(0, 4); // strip leading /sys
+        auto event = gen_udev_base_event(dev_path, sys_path);
+        event["SUBSYSTEM"] = "hidraw";
+        append_switch_identity(event, switch_hid_identity(base_path, uniq));
+        events.emplace_back(event);
+      }
+    }
+  }
+
+  return events;
+}
+
+std::vector<Joypad::UdevHwDbEntry> SwitchJoypad::get_udev_hw_db_entries() const {
+  std::vector<Joypad::UdevHwDbEntry> result;
+  const auto uniq = this->get_mac_address();
+
+  for (const auto &sys_entry : this->get_sys_nodes()) {
+    for (const auto &sys_node : std::filesystem::directory_iterator{sys_entry}) {
+      if (!sys_node.is_directory() || sys_node.path().filename().string().rfind("event", 0) != 0) {
+        continue;
+      }
+
+      auto dev_path = ("/dev/input/" / sys_node.path().filename()).string();
+      Joypad::UdevHwDbEntry entry;
+      entry.first = gen_udev_hw_db_filename(dev_path);
+
+      std::ifstream name_file(std::filesystem::path(sys_entry) / "name");
+      std::string name;
+      std::getline(name_file, name);
+      auto identity = switch_input_identity(sys_entry, uniq);
+
+      if (name.find("Motion") != std::string::npos || name.find("IMU") != std::string::npos) {
+        entry.second =
+            {"E:ID_INPUT=1", "E:ID_INPUT_ACCELEROMETER=1", "G:seat", "G:uaccess", "Q:seat", "Q:uaccess", "V:1"};
+      } else {
+        entry.second = {"E:ID_INPUT=1", "E:ID_INPUT_JOYSTICK=1", "G:seat", "G:uaccess", "Q:seat", "Q:uaccess", "V:1"};
+      }
+      append_switch_identity(entry.second, identity);
+      result.emplace_back(entry);
+    }
+  }
+
+  auto sys_nodes = this->get_sys_nodes();
+  if (!sys_nodes.empty()) {
+    auto base_path = std::filesystem::path(sys_nodes[0]).parent_path().parent_path();
+    if (std::filesystem::exists(base_path / "hidraw")) {
+      for (const auto &hidraw_entry : std::filesystem::directory_iterator{base_path / "hidraw"}) {
+        auto dev_path = "/dev/" + hidraw_entry.path().filename().string();
+        std::vector<std::string> rows = {"E:SUBSYSTEM=hidraw", "G:seat", "G:uaccess", "Q:seat", "Q:uaccess", "V:1"};
+        append_switch_identity(rows, switch_hid_identity(base_path, uniq));
+        result.push_back({gen_udev_hw_db_filename(dev_path), rows});
+      }
+    }
+  }
+
+  return result;
+}
+
+} // namespace inputtino

--- a/src/uhid/uhid.cpp
+++ b/src/uhid/uhid.cpp
@@ -1,0 +1,50 @@
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <uhid/uhid.hpp>
+
+namespace uhid {
+
+std::vector<std::string> find_uhid_sys_nodes(uint16_t vendor_id, const inputtino::Mac &mac) {
+  const std::string base_path = "/sys/devices/virtual/misc/uhid";
+  std::vector<std::string> nodes;
+  if (!std::filesystem::exists(base_path)) {
+    return nodes;
+  }
+
+  std::ostringstream target_id;
+  target_id << std::uppercase << std::hex << std::setfill('0') << std::setw(4)
+            << static_cast<unsigned int>(vendor_id);
+
+  for (const auto &uhid_entry : std::filesystem::directory_iterator{base_path}) {
+    if (!uhid_entry.is_directory()) {
+      continue;
+    }
+    if (uhid_entry.path().filename().string().find(target_id.str()) == std::string::npos) {
+      continue;
+    }
+    auto input_path = uhid_entry.path() / "input";
+    if (!std::filesystem::exists(input_path)) {
+      continue;
+    }
+    for (const auto &dev_entry : std::filesystem::directory_iterator{input_path}) {
+      if (!dev_entry.is_directory()) {
+        continue;
+      }
+      auto uniq_path = dev_entry.path() / "uniq";
+      if (!std::filesystem::exists(uniq_path)) {
+        continue;
+      }
+      std::ifstream uniq_file{uniq_path};
+      std::string uniq_value;
+      std::getline(uniq_file, uniq_value);
+      if (mac.matches(uniq_value)) {
+        nodes.push_back(dev_entry.path().string());
+      }
+    }
+  }
+  return nodes;
+}
+
+} // namespace uhid

--- a/src/uinput/include/inputtino/protected_ps5_types.hpp
+++ b/src/uinput/include/inputtino/protected_ps5_types.hpp
@@ -3,5 +3,5 @@
 #include <inputtino/input.hpp>
 
 namespace inputtino {
-struct PS5JoypadState : BaseJoypadState {};
+struct PS5JoypadUinputState : BaseJoypadState {};
 } // namespace inputtino

--- a/src/uinput/include/inputtino/protected_types.hpp
+++ b/src/uinput/include/inputtino/protected_types.hpp
@@ -51,7 +51,7 @@ struct BaseJoypadState {
 };
 
 struct XboxOneJoypadState : BaseJoypadState {};
-struct SwitchJoypadState : BaseJoypadState {};
+struct SwitchJoypadUinputState : BaseJoypadState {};
 
 struct KeyboardState {
   std::thread repeat_press_t;

--- a/src/uinput/include/inputtino/protected_types.hpp
+++ b/src/uinput/include/inputtino/protected_types.hpp
@@ -45,7 +45,9 @@ struct BaseJoypadState {
   bool stop_listening_events = false;
   std::thread events_thread;
 
+
   std::optional<std::function<void(int low_freq, int high_freq)>> on_rumble = std::nullopt;
+
 };
 
 struct XboxOneJoypadState : BaseJoypadState {};

--- a/src/uinput/joypad_nintendo.cpp
+++ b/src/uinput/joypad_nintendo.cpp
@@ -21,7 +21,15 @@ std::vector<std::string> SwitchJoypad::get_nodes() const {
   return nodes;
 }
 
-Result<libevdev_uinput_ptr> create_nintendo_controller(const DeviceDefinition &device) {
+std::vector<Joypad::UdevEvent> SwitchJoypad::get_udev_events() const {
+  return gen_joystick_udev_events(_state);
+}
+
+std::vector<Joypad::UdevHwDbEntry> SwitchJoypad::get_udev_hw_db_entries() const {
+  return gen_joystick_udev_hw_db(_state);
+}
+
+static Result<libevdev_uinput_ptr> create_nintendo_controller(const DeviceDefinition &device) {
   libevdev *dev = libevdev_new();
   libevdev_uinput *uidev;
 
@@ -99,8 +107,7 @@ Result<SwitchJoypad> SwitchJoypad::create(const DeviceDefinition &device) {
   SwitchJoypad joypad;
   joypad._state->joy = std::move(*joy_el);
 
-  auto event_thread = std::thread(event_listener, joypad._state);
-  joypad._state->events_thread = std::move(event_thread);
+  joypad._state->events_thread = std::thread(event_listener, joypad._state);
   joypad._state->events_thread.detach();
 
   return joypad;
@@ -187,4 +194,8 @@ void SwitchJoypad::set_triggers(int16_t left, int16_t right) {
 void SwitchJoypad::set_on_rumble(const std::function<void(int, int)> &callback) {
   this->_state->on_rumble = callback;
 }
+
+// Motion isn't available on the plain uinput backend; the Joypad base provides a
+// no-op set_gyro()/set_accel() and supports_motion() stays false.
+
 } // namespace inputtino

--- a/src/uinput/joypad_nintendo.cpp
+++ b/src/uinput/joypad_nintendo.cpp
@@ -10,7 +10,7 @@
 
 namespace inputtino {
 
-std::vector<std::string> SwitchJoypad::get_nodes() const {
+std::vector<std::string> SwitchJoypadUinput::get_nodes() const {
   std::vector<std::string> nodes;
 
   if (auto joy = _state->joy.get()) {
@@ -21,11 +21,11 @@ std::vector<std::string> SwitchJoypad::get_nodes() const {
   return nodes;
 }
 
-std::vector<Joypad::UdevEvent> SwitchJoypad::get_udev_events() const {
+std::vector<Joypad::UdevEvent> SwitchJoypadUinput::get_udev_events() const {
   return gen_joystick_udev_events(_state);
 }
 
-std::vector<Joypad::UdevHwDbEntry> SwitchJoypad::get_udev_hw_db_entries() const {
+std::vector<Joypad::UdevHwDbEntry> SwitchJoypadUinput::get_udev_hw_db_entries() const {
   return gen_joystick_udev_hw_db(_state);
 }
 
@@ -87,9 +87,9 @@ static Result<libevdev_uinput_ptr> create_nintendo_controller(const DeviceDefini
   return libevdev_uinput_ptr{uidev, ::libevdev_uinput_destroy};
 }
 
-SwitchJoypad::SwitchJoypad() : _state(std::make_shared<SwitchJoypadState>()) {}
+SwitchJoypadUinput::SwitchJoypadUinput() : _state(std::make_shared<SwitchJoypadUinputState>()) {}
 
-SwitchJoypad::~SwitchJoypad() {
+SwitchJoypadUinput::~SwitchJoypadUinput() {
   if (_state) {
     _state->stop_listening_events = true;
     if (_state->joy.get() != nullptr && _state->events_thread.joinable()) {
@@ -98,13 +98,13 @@ SwitchJoypad::~SwitchJoypad() {
   }
 }
 
-Result<SwitchJoypad> SwitchJoypad::create(const DeviceDefinition &device) {
+Result<SwitchJoypadUinput> SwitchJoypadUinput::create(const DeviceDefinition &device) {
   auto joy_el = create_nintendo_controller(device);
   if (!joy_el) {
     return Error(joy_el.getErrorMessage());
   }
 
-  SwitchJoypad joypad;
+  SwitchJoypadUinput joypad;
   joypad._state->joy = std::move(*joy_el);
 
   joypad._state->events_thread = std::thread(event_listener, joypad._state);
@@ -112,8 +112,7 @@ Result<SwitchJoypad> SwitchJoypad::create(const DeviceDefinition &device) {
 
   return joypad;
 }
-
-void SwitchJoypad::set_pressed_buttons(unsigned int newly_pressed) {
+void SwitchJoypadUinput::set_pressed_buttons(unsigned int newly_pressed) {
   // Button flags that have been changed between current and prev
   auto bf_changed = newly_pressed ^ this->_state->currently_pressed_btns;
   // Button flags that are only part of the new packet
@@ -151,14 +150,16 @@ void SwitchJoypad::set_pressed_buttons(unsigned int newly_pressed) {
         // Capture button
         libevdev_uinput_write_event(controller, EV_KEY, BTN_Z, bf_new & MISC_FLAG ? 1 : 0);
       }
+      // Positional remap to keep the Joypad API (Xbox naming) consistent
+      // across backends. See also src/uhid/joypad_switch.cpp.
       if (A & bf_changed)
-        libevdev_uinput_write_event(controller, EV_KEY, BTN_EAST, bf_new & A ? 1 : 0);
+        libevdev_uinput_write_event(controller, EV_KEY, BTN_SOUTH, bf_new & A ? 1 : 0);
       if (B & bf_changed)
-        libevdev_uinput_write_event(controller, EV_KEY, BTN_SOUTH, bf_new & B ? 1 : 0);
+        libevdev_uinput_write_event(controller, EV_KEY, BTN_EAST, bf_new & B ? 1 : 0);
       if (X & bf_changed)
-        libevdev_uinput_write_event(controller, EV_KEY, BTN_NORTH, bf_new & X ? 1 : 0);
+        libevdev_uinput_write_event(controller, EV_KEY, BTN_WEST, bf_new & X ? 1 : 0);
       if (Y & bf_changed)
-        libevdev_uinput_write_event(controller, EV_KEY, BTN_WEST, bf_new & Y ? 1 : 0);
+        libevdev_uinput_write_event(controller, EV_KEY, BTN_NORTH, bf_new & Y ? 1 : 0);
     }
 
     libevdev_uinput_write_event(controller, EV_SYN, SYN_REPORT, 0);
@@ -166,7 +167,7 @@ void SwitchJoypad::set_pressed_buttons(unsigned int newly_pressed) {
   this->_state->currently_pressed_btns = bf_new;
 }
 
-void SwitchJoypad::set_stick(Joypad::STICK_POSITION stick_type, short x, short y) {
+void SwitchJoypadUinput::set_stick(Joypad::STICK_POSITION stick_type, short x, short y) {
   if (auto controller = this->_state->joy.get()) {
     if (stick_type == LS) {
       libevdev_uinput_write_event(controller, EV_ABS, ABS_X, x);
@@ -180,7 +181,7 @@ void SwitchJoypad::set_stick(Joypad::STICK_POSITION stick_type, short x, short y
   }
 }
 
-void SwitchJoypad::set_triggers(int16_t left, int16_t right) {
+void SwitchJoypadUinput::set_triggers(int16_t left, int16_t right) {
   if (auto controller = this->_state->joy.get()) {
     // Nintendo ZL and ZR are just buttons (EV_KEY)
     libevdev_uinput_write_event(controller, EV_KEY, BTN_TL2, left > 0 ? 1 : 0);
@@ -191,7 +192,7 @@ void SwitchJoypad::set_triggers(int16_t left, int16_t right) {
   }
 }
 
-void SwitchJoypad::set_on_rumble(const std::function<void(int, int)> &callback) {
+void SwitchJoypadUinput::set_on_rumble(const std::function<void(int, int)> &callback) {
   this->_state->on_rumble = callback;
 }
 

--- a/src/uinput/joypad_ps.cpp
+++ b/src/uinput/joypad_ps.cpp
@@ -9,7 +9,7 @@
 
 namespace inputtino {
 
-std::vector<std::string> PS5Joypad::get_nodes() const {
+std::vector<std::string> PS5JoypadUinput::get_nodes() const {
   std::vector<std::string> nodes;
 
   if (auto joy = _state->joy.get()) {
@@ -20,7 +20,15 @@ std::vector<std::string> PS5Joypad::get_nodes() const {
   return nodes;
 }
 
-Result<libevdev_uinput_ptr> create_ps_controller(const DeviceDefinition &device) {
+std::vector<Joypad::UdevEvent> PS5JoypadUinput::get_udev_events() const {
+  return gen_joystick_udev_events(_state);
+}
+
+std::vector<Joypad::UdevHwDbEntry> PS5JoypadUinput::get_udev_hw_db_entries() const {
+  return gen_joystick_udev_hw_db(_state);
+}
+
+static Result<libevdev_uinput_ptr> create_ps_controller(const DeviceDefinition &device) {
   libevdev *dev = libevdev_new();
   libevdev_uinput *uidev;
 
@@ -79,10 +87,9 @@ Result<libevdev_uinput_ptr> create_ps_controller(const DeviceDefinition &device)
   return libevdev_uinput_ptr{uidev, ::libevdev_uinput_destroy};
 }
 
-PS5Joypad::PS5Joypad(uint16_t vendor_id, std::array<unsigned char, 6> mac_address) : _state(std::make_shared<PS5JoypadState>()) {
-}
+PS5JoypadUinput::PS5JoypadUinput() : _state(std::make_shared<PS5JoypadUinputState>()) {}
 
-PS5Joypad::~PS5Joypad() {
+PS5JoypadUinput::~PS5JoypadUinput() {
   if (_state) {
     _state->stop_listening_events = true;
     if (_state->joy.get() != nullptr && _state->events_thread.joinable()) {
@@ -91,23 +98,21 @@ PS5Joypad::~PS5Joypad() {
   }
 }
 
-Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device) {
+Result<PS5JoypadUinput> PS5JoypadUinput::create(const DeviceDefinition &device) {
   auto joy_el = create_ps_controller(device);
   if (!joy_el) {
     return Error(joy_el.getErrorMessage());
   }
 
-  PS5Joypad joypad(0);
+  PS5JoypadUinput joypad;
   joypad._state->joy = std::move(*joy_el);
 
-  auto event_thread = std::thread(event_listener, joypad._state);
-  joypad._state->events_thread = std::move(event_thread);
+  joypad._state->events_thread = std::thread(event_listener, joypad._state);
   joypad._state->events_thread.detach();
 
   return joypad;
 }
-
-void PS5Joypad::set_pressed_buttons(unsigned int newly_pressed) {
+void PS5JoypadUinput::set_pressed_buttons(unsigned int newly_pressed) {
   // Button flags that have been changed between current and prev
   auto bf_changed = newly_pressed ^ this->_state->currently_pressed_btns;
   // Button flags that are only part of the new packet
@@ -156,7 +161,7 @@ void PS5Joypad::set_pressed_buttons(unsigned int newly_pressed) {
   this->_state->currently_pressed_btns = bf_new;
 }
 
-void PS5Joypad::set_stick(Joypad::STICK_POSITION stick_type, short x, short y) {
+void PS5JoypadUinput::set_stick(Joypad::STICK_POSITION stick_type, short x, short y) {
   if (auto controller = this->_state->joy.get()) {
     if (stick_type == LS) {
       libevdev_uinput_write_event(controller, EV_ABS, ABS_X, x);
@@ -170,34 +175,20 @@ void PS5Joypad::set_stick(Joypad::STICK_POSITION stick_type, short x, short y) {
   }
 }
 
-void PS5Joypad::set_triggers(int16_t left, int16_t right) {
+void PS5JoypadUinput::set_triggers(int16_t left, int16_t right) {
   if (auto controller = this->_state->joy.get()) {
-    if (left > 0) {
-      libevdev_uinput_write_event(controller, EV_ABS, ABS_Z, left);
-    } else {
-      libevdev_uinput_write_event(controller, EV_ABS, ABS_Z, left);
-    }
-
-    if (right > 0) {
-      libevdev_uinput_write_event(controller, EV_ABS, ABS_RZ, right);
-    } else {
-      libevdev_uinput_write_event(controller, EV_ABS, ABS_RZ, right);
-    }
-
+    libevdev_uinput_write_event(controller, EV_ABS, ABS_Z, left);
+    libevdev_uinput_write_event(controller, EV_ABS, ABS_RZ, right);
     libevdev_uinput_write_event(controller, EV_SYN, SYN_REPORT, 0);
   }
 }
 
-void PS5Joypad::set_on_rumble(const std::function<void(int, int)> &callback) {
+void PS5JoypadUinput::set_on_rumble(const std::function<void(int, int)> &callback) {
   this->_state->on_rumble = callback;
 }
 
-// Followings aren't supported when not using the UHID implementation
-void PS5Joypad::place_finger(int finger_nr, uint16_t x, uint16_t y) {}
-void PS5Joypad::release_finger(int finger_nr) {}
-void PS5Joypad::set_motion(MOTION_TYPE type, float x, float y, float z) {}
-void PS5Joypad::set_battery(BATTERY_STATE state, int percentage) {}
-void PS5Joypad::set_on_led(const std::function<void(int r, int g, int b)> &callback) {}
-void PS5Joypad::set_on_trigger_effect(const std::function<void(const TriggerEffect &)> &callback) {}
+// Touchpad, motion, battery, LED and adaptive triggers aren't available on the
+// plain uinput backend; the Joypad base provides no-op defaults for them and
+// supports_motion() stays false.
 
 } // namespace inputtino

--- a/src/uinput/joypad_utils.hpp
+++ b/src/uinput/joypad_utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <algorithm>
+#include <udev_helpers.hpp>
 #include <chrono>
 #include <cstring>
 #include <fcntl.h>
@@ -170,6 +171,7 @@ static void event_listener(const std::shared_ptr<BaseJoypadState> &state) {
   std::array<pollfd, 1> pfds = {pollfd{.fd = uinput_fd, .events = POLLIN}};
   int poll_rs = 0;
 
+  // Keep listening until the joypad is being torn down (stop_listening_events).
   while (!state->stop_listening_events) {
     poll_rs = poll(pfds.data(), pfds.size(), RUMBLE_POLL_TIMEOUT);
     if (poll_rs < 0) {
@@ -241,6 +243,42 @@ static void event_listener(const std::shared_ptr<BaseJoypadState> &state) {
       }
     }
   }
+}
+
+// Build the udev metadata for a plain uinput joystick (Xbox / uinput PS / uinput
+// Nintendo): a base "add" event per child node tagged as a joystick, plus a
+// single hwdb entry for the main node. Shared by the uinput joypad backends so
+// each one's get_udev_events()/get_udev_hw_db_entries() is a one-liner.
+static std::vector<Joypad::UdevEvent> gen_joystick_udev_events(const std::shared_ptr<BaseJoypadState> &state) {
+  std::vector<Joypad::UdevEvent> events;
+  if (auto joy = state->joy.get()) {
+    for (const auto &devnode : get_child_dev_nodes(joy)) {
+      std::string syspath = libevdev_uinput_get_syspath(joy);
+      syspath.erase(0, 4); // strip leading /sys
+      syspath.append("/" + std::filesystem::path(devnode).filename().string());
+      auto event = gen_udev_base_event(devnode, syspath);
+      event["ID_INPUT_JOYSTICK"] = "1";
+      event[".INPUT_CLASS"] = "joystick";
+      events.emplace_back(event);
+    }
+  }
+  return events;
+}
+
+static std::vector<Joypad::UdevHwDbEntry> gen_joystick_udev_hw_db(const std::shared_ptr<BaseJoypadState> &state) {
+  std::vector<Joypad::UdevHwDbEntry> result;
+  if (auto joy = state->joy.get()) {
+    result.push_back({gen_udev_hw_db_filename(libevdev_uinput_get_devnode(joy)),
+                      {"E:ID_INPUT=1",
+                       "E:ID_INPUT_JOYSTICK=1",
+                       "E:ID_BUS=usb",
+                       "G:seat",
+                       "G:uaccess",
+                       "Q:seat",
+                       "Q:uaccess",
+                       "V:1"}});
+  }
+  return result;
 }
 
 } // namespace inputtino

--- a/src/uinput/joypad_xbox.cpp
+++ b/src/uinput/joypad_xbox.cpp
@@ -20,6 +20,14 @@ std::vector<std::string> XboxOneJoypad::get_nodes() const {
   return nodes;
 }
 
+std::vector<Joypad::UdevEvent> XboxOneJoypad::get_udev_events() const {
+  return gen_joystick_udev_events(_state);
+}
+
+std::vector<Joypad::UdevHwDbEntry> XboxOneJoypad::get_udev_hw_db_entries() const {
+  return gen_joystick_udev_hw_db(_state);
+}
+
 Result<libevdev_uinput_ptr> create_xbox_controller(const DeviceDefinition &device) {
   libevdev *dev = libevdev_new();
   libevdev_uinput *uidev;
@@ -101,7 +109,6 @@ Result<XboxOneJoypad> XboxOneJoypad::create(const DeviceDefinition &device) {
   joypad._state->events_thread.detach();
   return joypad;
 }
-
 void XboxOneJoypad::set_pressed_buttons(unsigned int newly_pressed) {
   // Button flags that have been changed between current and prev
   auto bf_changed = newly_pressed ^ this->_state->currently_pressed_btns;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,9 @@ add_executable(inputtino_tests main.cpp)
 set(SRC_LIST main.cpp testCAPI.cpp)
 
 if (UNIX AND NOT APPLE)
+    # Runtime factory / backend-selection / udev tests (no SDL or libinput needed)
+    list(APPEND SRC_LIST "testFactory.cpp")
+
     option(TEST_LIBINPUT "Enable libinput test" ON)
     if (TEST_LIBINPUT)
         find_package(PkgConfig)

--- a/tests/testCAPI.cpp
+++ b/tests/testCAPI.cpp
@@ -167,10 +167,10 @@ TEST_CASE("C Switch API", "[C-API]") {
   int num_nodes = 0;
   auto nodes = inputtino_joypad_switch_get_nodes(switch_, &num_nodes);
   REQUIRE(num_nodes >= 1);
-  REQUIRE_THAT(std::string(nodes[0]), Catch::Matchers::StartsWith("/dev/input/"));
-
-  REQUIRE(std::filesystem::exists(nodes[0]));
-  REQUIRE(std::filesystem::exists(nodes[1]));
+  for (int i = 0; i < num_nodes; i++) {
+    REQUIRE_THAT(std::string(nodes[i]), Catch::Matchers::StartsWith("/dev/input/"));
+    REQUIRE(std::filesystem::exists(nodes[i]));
+  }
 
   { // TODO: test that this actually work
     inputtino_joypad_switch_set_pressed_buttons(switch_, INPUTTINO_JOYPAD_BTN::A | INPUTTINO_JOYPAD_BTN::B);

--- a/tests/testCAPI.cpp
+++ b/tests/testCAPI.cpp
@@ -155,15 +155,19 @@ TEST_CASE("C XOne API", "[C-API]") {
 TEST_CASE("C Switch API", "[C-API]") {
   InputtinoErrorHandler error_handler = {.eh = [](const char *message, void *_data) { FAIL(message); },
                                          .user_data = nullptr};
-  InputtinoDeviceDefinition def = {};
+  InputtinoDeviceDefinition def = {
+      .name = "Pro Controller",
+      .vendor_id = 0x057E,
+      .product_id = 0x2009,
+      .version = 0x8111,
+  };
   auto switch_ = inputtino_joypad_switch_create(&def, &error_handler);
   REQUIRE(switch_ != nullptr);
 
   int num_nodes = 0;
   auto nodes = inputtino_joypad_switch_get_nodes(switch_, &num_nodes);
-  REQUIRE(num_nodes == 2);
-  REQUIRE_THAT(std::string(nodes[0]), Catch::Matchers::StartsWith("/dev/input/event"));
-  REQUIRE_THAT(std::string(nodes[1]), Catch::Matchers::StartsWith("/dev/input/js"));
+  REQUIRE(num_nodes >= 1);
+  REQUIRE_THAT(std::string(nodes[0]), Catch::Matchers::StartsWith("/dev/input/"));
 
   REQUIRE(std::filesystem::exists(nodes[0]));
   REQUIRE(std::filesystem::exists(nodes[1]));

--- a/tests/testFactory.cpp
+++ b/tests/testFactory.cpp
@@ -41,7 +41,7 @@ TEST_CASE("uinput DualSense pad: no rich features, safe no-ops, self-describes",
 }
 
 TEST_CASE("uinput Nintendo pad: no motion, self-describes", "[Factory]") {
-  auto created = SwitchJoypad::create();
+  auto created = SwitchJoypadUinput::create();
   REQUIRE(created);
   auto joypad = std::move(*created);
 
@@ -73,10 +73,14 @@ TEST_CASE("Joypad::create picks the rich uhid backend when preferred", "[Factory
     SKIP("This host has no accessible /dev/uhid");
   }
 
-  // The uhid DualSense forwards motion; that's the observable difference from
-  // its uinput fallback. (The uhid Switch Pro backend lands in a follow-up PR.)
+  // The uhid DualSense / Switch Pro pads forward motion; that's the observable
+  // difference from their uinput fallbacks.
   auto ps = Joypad::create(Joypad::TYPE::PS, /* prefer_uhid */ true);
   REQUIRE(ps);
   REQUIRE((*ps)->supports_motion());
+
+  auto nintendo = Joypad::create(Joypad::TYPE::NINTENDO, /* prefer_uhid */ true);
+  REQUIRE(nintendo);
+  REQUIRE((*nintendo)->supports_motion());
 }
 #endif

--- a/tests/testFactory.cpp
+++ b/tests/testFactory.cpp
@@ -67,6 +67,16 @@ TEST_CASE("Joypad::create returns a usable pad through the Joypad base", "[Facto
   REQUIRE_FALSE((*xbox)->get_udev_events().empty());
 }
 
+TEST_CASE("Joypad::create routes Joy-Con L/R through the Nintendo backend", "[Factory]") {
+  // Deterministic uinput path: the new enum values just have to route through
+  // the factory (no "unknown Joypad::TYPE") and produce a self-describing pad.
+  for (auto type : {Joypad::TYPE::JOYCON_LEFT, Joypad::TYPE::JOYCON_RIGHT}) {
+    auto jc = Joypad::create(type, /* prefer_uhid */ false);
+    REQUIRE(jc);
+    REQUIRE_FALSE((*jc)->get_udev_events().empty());
+  }
+}
+
 #ifdef USE_UHID
 TEST_CASE("Joypad::create picks the rich uhid backend when preferred", "[Factory][UHID]") {
   if (!is_uhid_supported()) {
@@ -82,5 +92,24 @@ TEST_CASE("Joypad::create picks the rich uhid backend when preferred", "[Factory
   auto nintendo = Joypad::create(Joypad::TYPE::NINTENDO, /* prefer_uhid */ true);
   REQUIRE(nintendo);
   REQUIRE((*nintendo)->supports_motion());
+}
+
+TEST_CASE("Joypad::create gives Joy-Con L/R the right hid-nintendo product id", "[Factory][UHID]") {
+  if (!is_uhid_supported()) {
+    SKIP("This host has no accessible /dev/uhid");
+  }
+  // The factory owns the Joy-Con identity (see default_definition); confirm the
+  // L/R product ids reach the uhid SwitchJoypad that hid-nintendo keys off.
+  auto left = Joypad::create(Joypad::TYPE::JOYCON_LEFT, /* prefer_uhid */ true);
+  REQUIRE(left);
+  auto *swl = dynamic_cast<SwitchJoypad *>((*left).get());
+  REQUIRE(swl != nullptr);
+  REQUIRE(swl->get_product_id() == 0x2006);
+
+  auto right = Joypad::create(Joypad::TYPE::JOYCON_RIGHT, /* prefer_uhid */ true);
+  REQUIRE(right);
+  auto *swr = dynamic_cast<SwitchJoypad *>((*right).get());
+  REQUIRE(swr != nullptr);
+  REQUIRE(swr->get_product_id() == 0x2007);
 }
 #endif

--- a/tests/testFactory.cpp
+++ b/tests/testFactory.cpp
@@ -1,0 +1,82 @@
+#include <catch2/catch_test_macros.hpp>
+#include <inputtino/input.hpp>
+
+using namespace inputtino;
+
+// These cover the runtime backend selection, the basic uinput joypad backends
+// and the self-describing udev metadata. They deliberately avoid the SDL/HIDAPI
+// round-trip (see testUHID/testJoypads) so they stay deterministic.
+
+TEST_CASE("is_uhid_supported is stable across calls", "[Factory]") {
+  const bool supported = is_uhid_supported();
+  REQUIRE(is_uhid_supported() == supported);
+}
+
+TEST_CASE("uinput DualSense pad: no rich features, safe no-ops, self-describes", "[Factory]") {
+  auto created = PS5JoypadUinput::create();
+  REQUIRE(created);
+  auto joypad = std::move(*created);
+
+  // The uinput backend has no motion; the rich setters inherited from the
+  // Joypad base must be safe no-ops rather than crash.
+  REQUIRE_FALSE(joypad.supports_motion());
+  joypad.set_accel(1.f, 2.f, 3.f);
+  joypad.set_gyro(1.f, 2.f, 3.f);
+  joypad.set_battery(Joypad::BATTERY_FULL, 100);
+  joypad.place_finger(0, 10, 10);
+  joypad.release_finger(0);
+
+  // It still presents at least one joystick node to udev.
+  auto events = joypad.get_udev_events();
+  REQUIRE_FALSE(events.empty());
+  bool has_joystick = false;
+  for (const auto &ev : events) {
+    auto it = ev.find("ID_INPUT_JOYSTICK");
+    if (it != ev.end() && it->second == "1") {
+      has_joystick = true;
+    }
+  }
+  REQUIRE(has_joystick);
+  REQUIRE_FALSE(joypad.get_udev_hw_db_entries().empty());
+}
+
+TEST_CASE("uinput Nintendo pad: no motion, self-describes", "[Factory]") {
+  auto created = SwitchJoypad::create();
+  REQUIRE(created);
+  auto joypad = std::move(*created);
+
+  REQUIRE_FALSE(joypad.supports_motion());
+  joypad.set_gyro(0.f, 0.f, 0.f); // no-op, must not crash
+  REQUIRE_FALSE(joypad.get_udev_events().empty());
+}
+
+TEST_CASE("Joypad::create returns a usable pad through the Joypad base", "[Factory]") {
+  // prefer_uhid = false always yields the uinput backend, which has no motion.
+  auto ps = Joypad::create(Joypad::TYPE::PS, /* prefer_uhid */ false);
+  REQUIRE(ps);
+  REQUIRE_FALSE((*ps)->supports_motion());
+  REQUIRE_FALSE((*ps)->get_udev_events().empty());
+
+  auto nintendo = Joypad::create(Joypad::TYPE::NINTENDO, /* prefer_uhid */ false);
+  REQUIRE(nintendo);
+  REQUIRE_FALSE((*nintendo)->supports_motion());
+
+  auto xbox = Joypad::create(Joypad::TYPE::XBOX);
+  REQUIRE(xbox);
+  REQUIRE_FALSE((*xbox)->supports_motion());
+  REQUIRE_FALSE((*xbox)->get_udev_events().empty());
+}
+
+#ifdef USE_UHID
+TEST_CASE("Joypad::create picks the rich uhid backend when preferred", "[Factory][UHID]") {
+  if (!is_uhid_supported()) {
+    SKIP("This host has no accessible /dev/uhid");
+  }
+
+  // The uhid DualSense forwards motion; that's the observable difference from
+  // its uinput fallback. (The uhid Switch Pro backend lands in a follow-up PR.)
+  auto ps = Joypad::create(Joypad::TYPE::PS, /* prefer_uhid */ true);
+  REQUIRE(ps);
+  REQUIRE((*ps)->supports_motion());
+}
+#endif

--- a/tests/testJoypads.cpp
+++ b/tests/testJoypads.cpp
@@ -71,7 +71,7 @@ public:
   flush_sdl_events();                                                                                                  \
   REQUIRE(SDL_GameControllerGetButton(gc, SDL_BTN) == 1);
 
-static void test_buttons(SDL_GameController *gc, Joypad &joypad) {
+static void test_buttons(SDL_GameController *gc, Joypad &joypad, bool nintendo_layout = false) {
   SDL_TEST_BUTTON(Joypad::DPAD_UP, SDL_CONTROLLER_BUTTON_DPAD_UP)
   SDL_TEST_BUTTON(Joypad::DPAD_DOWN, SDL_CONTROLLER_BUTTON_DPAD_DOWN)
   SDL_TEST_BUTTON(Joypad::DPAD_LEFT, SDL_CONTROLLER_BUTTON_DPAD_LEFT)
@@ -82,10 +82,23 @@ static void test_buttons(SDL_GameController *gc, Joypad &joypad) {
   SDL_TEST_BUTTON(Joypad::LEFT_BUTTON, SDL_CONTROLLER_BUTTON_LEFTSHOULDER)
   SDL_TEST_BUTTON(Joypad::RIGHT_BUTTON, SDL_CONTROLLER_BUTTON_RIGHTSHOULDER)
 
-  SDL_TEST_BUTTON(Joypad::A, SDL_CONTROLLER_BUTTON_A)
-  SDL_TEST_BUTTON(Joypad::B, SDL_CONTROLLER_BUTTON_B)
-  SDL_TEST_BUTTON(Joypad::X, SDL_CONTROLLER_BUTTON_X)
-  SDL_TEST_BUTTON(Joypad::Y, SDL_CONTROLLER_BUTTON_Y)
+  // Face buttons: the Joypad enum uses Xbox naming (A=south, B=east,
+  // X=west, Y=north) and inputtino remaps positionally when driving
+  // Nintendo-labeled hardware. SDL2 on Switch Pro, however, keeps the
+  // Nintendo face-button labels in SDL_CONTROLLER_BUTTON_* (fixed in
+  // SDL3 via SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS), so a physically
+  // correct south-button press arrives as SDL's B, east as A, etc.
+  if (nintendo_layout) {
+    SDL_TEST_BUTTON(Joypad::A, SDL_CONTROLLER_BUTTON_B)
+    SDL_TEST_BUTTON(Joypad::B, SDL_CONTROLLER_BUTTON_A)
+    SDL_TEST_BUTTON(Joypad::X, SDL_CONTROLLER_BUTTON_Y)
+    SDL_TEST_BUTTON(Joypad::Y, SDL_CONTROLLER_BUTTON_X)
+  } else {
+    SDL_TEST_BUTTON(Joypad::A, SDL_CONTROLLER_BUTTON_A)
+    SDL_TEST_BUTTON(Joypad::B, SDL_CONTROLLER_BUTTON_B)
+    SDL_TEST_BUTTON(Joypad::X, SDL_CONTROLLER_BUTTON_X)
+    SDL_TEST_BUTTON(Joypad::Y, SDL_CONTROLLER_BUTTON_Y)
+  }
 
   SDL_TEST_BUTTON(Joypad::START, SDL_CONTROLLER_BUTTON_START)
   SDL_TEST_BUTTON(Joypad::BACK, SDL_CONTROLLER_BUTTON_BACK)
@@ -185,12 +198,16 @@ TEST_CASE_METHOD(SDLTestsFixture, "Nintendo Joypad", "[SDL]") {
   // Create the controller
   auto joypad = std::move(*SwitchJoypad::create());
 
-  std::this_thread::sleep_for(150ms);
-
   auto devices = joypad.get_nodes();
+#ifdef USE_UHID
+  REQUIRE_THAT(devices, SizeIs(2)); // 1 controller event node and 1 IMU event node
+  REQUIRE_THAT(devices, Contains(ContainsSubstring("/dev/input/event")));
+  REQUIRE_THAT(devices, Contains(ContainsSubstring("/dev/input/event")));
+#else
   REQUIRE_THAT(devices, SizeIs(2)); // 1 eventXX and 1 jsYY
   REQUIRE_THAT(devices, Contains(ContainsSubstring("/dev/input/event")));
   REQUIRE_THAT(devices, Contains(ContainsSubstring("/dev/input/js")));
+#endif
 
   // Initializing the controller
   flush_sdl_events();
@@ -201,7 +218,7 @@ TEST_CASE_METHOD(SDLTestsFixture, "Nintendo Joypad", "[SDL]") {
   REQUIRE(gc);
   REQUIRE(SDL_GameControllerGetType(gc) == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO);
 
-  test_buttons(gc, joypad);
+  test_buttons(gc, joypad, /*nintendo_layout=*/true);
   { // Rumble
     // Checking for basic capability
     REQUIRE(SDL_GameControllerHasRumble(gc));
@@ -216,8 +233,15 @@ TEST_CASE_METHOD(SDLTestsFixture, "Nintendo Joypad", "[SDL]") {
     // https://github.com/libsdl-org/SDL/blob/da8fc70a83cf6b76d5ea75c39928a7961bd163d3/src/joystick/linux/SDL_sysjoystick.c#L1628
     SDL_GameControllerRumble(gc, 100, 200, 100);
     std::this_thread::sleep_for(30ms); // wait for the effect to be picked up
+#ifdef USE_UHID
+    // The Switch HID rumble protocol uses encoded amplitude buckets, so the
+    // exact SDL input values are not preserved across the round-trip.
+    REQUIRE(rumble_data->first > 0);
+    REQUIRE(rumble_data->second > 0);
+#else
     REQUIRE(rumble_data->first == 100);
     REQUIRE(rumble_data->second == 200);
+#endif
   }
 
   SDL_TEST_BUTTON(Joypad::MISC_FLAG, SDL_CONTROLLER_BUTTON_MISC1);
@@ -232,13 +256,27 @@ TEST_CASE_METHOD(SDLTestsFixture, "Nintendo Joypad", "[SDL]") {
 
     joypad.set_stick(Joypad::LS, 1000, 2000);
     flush_sdl_events();
+#ifdef USE_UHID
+    auto left_x = SDL_GameControllerGetAxis(gc, SDL_CONTROLLER_AXIS_LEFTX);
+    auto left_y = SDL_GameControllerGetAxis(gc, SDL_CONTROLLER_AXIS_LEFTY);
+    REQUIRE((left_x > 500 || left_x < -500));
+    REQUIRE((left_y > 500 || left_y < -500));
+#else
     REQUIRE(SDL_GameControllerGetAxis(gc, SDL_CONTROLLER_AXIS_LEFTX) == 1000);
     REQUIRE(SDL_GameControllerGetAxis(gc, SDL_CONTROLLER_AXIS_LEFTY) == -2000);
+#endif
 
     joypad.set_stick(Joypad::RS, 1000, 2000);
     flush_sdl_events();
+#ifdef USE_UHID
+    auto right_x = SDL_GameControllerGetAxis(gc, SDL_CONTROLLER_AXIS_RIGHTX);
+    auto right_y = SDL_GameControllerGetAxis(gc, SDL_CONTROLLER_AXIS_RIGHTY);
+    REQUIRE((right_x > 500 || right_x < -500));
+    REQUIRE((right_y > 500 || right_y < -500));
+#else
     REQUIRE(SDL_GameControllerGetAxis(gc, SDL_CONTROLLER_AXIS_RIGHTX) == 1000);
     REQUIRE(SDL_GameControllerGetAxis(gc, SDL_CONTROLLER_AXIS_RIGHTY) == -2000);
+#endif
 
     // Nintendo ONLY: triggers are buttons, so it can only be MAX or 0
     joypad.set_triggers(10, 20);

--- a/tests/testUHID.cpp
+++ b/tests/testUHID.cpp
@@ -470,9 +470,9 @@ TEST_CASE("Bluetooth CRC32", "[PS]") {
 
 TEST_CASE("Mac struct", "[Mac]") {
   SECTION("generate returns unique MACs") {
-    auto m1 = Mac::generate();
-    auto m2 = Mac::generate();
-    auto m3 = Mac::generate();
+    auto m1 = *Mac::generate();
+    auto m2 = *Mac::generate();
+    auto m3 = *Mac::generate();
     REQUIRE(m1 != m2);
     REQUIRE(m2 != m3);
     REQUIRE(m1 != m3);
@@ -481,33 +481,28 @@ TEST_CASE("Mac struct", "[Mac]") {
     REQUIRE(m1.bytes[1] == 0xBB);
     REQUIRE(m1.bytes[2] == 0xCC);
     REQUIRE(m1.bytes[3] == 0x00);
-    Mac::release(m1);
-    Mac::release(m2);
-    Mac::release(m3);
-  }
-
-  SECTION("release allows reuse") {
-    auto m1 = Mac::generate();
-    auto m1_copy = m1;
-    Mac::release(m1);
-    auto m2 = Mac::generate();
-    REQUIRE(m2 == m1_copy);
-    Mac::release(m2);
   }
 
   SECTION("parse and to_string round-trip") {
-    auto m = Mac::parse("AB:CD:EF:01:23:45");
+    auto m = *Mac::parse("AB:CD:EF:01:23:45");
     REQUIRE(m.to_string() == "ab:cd:ef:01:23:45");
     REQUIRE(m.bytes[0] == 0xAB);
     REQUIRE(m.bytes[5] == 0x45);
   }
 
   SECTION("matches is case-insensitive") {
-    auto m = Mac::parse("aa:bb:cc:dd:ee:ff");
+    auto m = *Mac::parse("aa:bb:cc:dd:ee:ff");
     REQUIRE(m.matches("AA:BB:CC:DD:EE:FF"));
     REQUIRE(m.matches("aa:bb:cc:dd:ee:ff"));
     REQUIRE(m.matches("Aa:Bb:Cc:Dd:Ee:Ff"));
     REQUIRE_FALSE(m.matches("00:00:00:00:00:00"));
+  }
+
+  SECTION("parse rejects malformed input") {
+    REQUIRE_FALSE(Mac::parse("not-a-mac"));
+    REQUIRE_FALSE(Mac::parse("aa:bb:cc:dd:ee"));
+    REQUIRE_FALSE(Mac::parse("aa:bb:cc:dd:ee:ff:00"));
+    REQUIRE_FALSE(Mac::parse("gg:bb:cc:dd:ee:ff"));
   }
 }
 

--- a/tests/testUHID.cpp
+++ b/tests/testUHID.cpp
@@ -9,6 +9,7 @@
 #include <SDL.h>
 #include <thread>
 #include <uhid/ps5.hpp>
+#include <uhid/switch.hpp>
 #include <unistd.h>
 
 using Catch::Matchers::Contains;
@@ -55,6 +56,43 @@ static std::filesystem::path wait_for_hidraw_by_uniq(const std::string &uniq,
   }
 
   return {};
+}
+
+static std::vector<uint8_t> read_hidraw_report(const std::filesystem::path &hidraw_path,
+                                               std::chrono::milliseconds timeout = 1500ms) {
+  int fd = open(hidraw_path.c_str(), O_RDONLY | O_NONBLOCK);
+  REQUIRE(fd >= 0);
+
+  std::vector<uint8_t> report(sizeof(uhid::switch_input_report));
+  auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    pollfd pfd = {.fd = fd, .events = POLLIN, .revents = 0};
+    if (poll(&pfd, 1, 50) <= 0) {
+      continue;
+    }
+
+    auto bytes = read(fd, report.data(), report.size());
+    if (bytes == static_cast<ssize_t>(report.size()) && report[0] == uhid::SWITCH_INPUT_REPORT_STANDARD_FULL) {
+      close(fd);
+      return report;
+    }
+  }
+
+  close(fd);
+  FAIL("Timed out waiting for hidraw Switch input report");
+  return {};
+}
+
+static std::array<uint8_t, 3> report_buttons(const std::vector<uint8_t> &report) {
+  return {report[3], report[4], report[5]};
+}
+
+static std::array<uint8_t, 3> report_left_stick(const std::vector<uint8_t> &report) {
+  return {report[6], report[7], report[8]};
+}
+
+static std::array<uint8_t, 3> report_right_stick(const std::vector<uint8_t> &report) {
+  return {report[9], report[10], report[11]};
 }
 
 static void flush_sdl_events() {
@@ -497,6 +535,229 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL],[PS]") {
   }
 
   SDL_GameControllerClose(gc);
+}
+
+TEST_CASE("Switch Joypad raw HID reports", "[UHID],[Switch]") {
+  DeviceDefinition def = {
+      .name = "Wolf Nintendo (virtual) pad",
+      .vendor_id = 0x057E,
+      .product_id = 0x2009,
+      .version = 0x8111,
+  };
+  auto joypad = std::move(*SwitchJoypad::create(def));
+
+  std::this_thread::sleep_for(150ms);
+
+  auto hidraw = wait_for_hidraw_by_uniq(joypad.get_mac_address(), def.vendor_id, def.product_id);
+  REQUIRE_FALSE(hidraw.empty());
+  REQUIRE(std::filesystem::exists(hidraw));
+
+  auto idle = read_hidraw_report(hidraw);
+  REQUIRE(idle[0] == uhid::SWITCH_INPUT_REPORT_STANDARD_FULL);
+  REQUIRE(idle[2] == 0x60);
+  REQUIRE(report_buttons(idle) == std::array<uint8_t, 3>{0x00, 0x80, 0x00});
+  REQUIRE(report_left_stick(idle) == std::array<uint8_t, 3>{0x00, 0x08, 0x80});
+  REQUIRE(report_right_stick(idle) == std::array<uint8_t, 3>{0x00, 0x08, 0x80});
+
+  joypad.set_stick(Joypad::LS, 1000, 2000);
+
+  bool saw_changed_left_stick = false;
+  for (int i = 0; i < 10; ++i) {
+    auto report = read_hidraw_report(hidraw, 300ms);
+    if (report_left_stick(report) != std::array<uint8_t, 3>{0x00, 0x08, 0x80}) {
+      saw_changed_left_stick = true;
+      break;
+    }
+  }
+  REQUIRE(saw_changed_left_stick);
+
+  joypad.set_pressed_buttons(Joypad::A);
+
+  bool saw_changed_buttons = false;
+  for (int i = 0; i < 10; ++i) {
+    auto report = read_hidraw_report(hidraw, 300ms);
+    if (report_buttons(report) != std::array<uint8_t, 3>{0x00, 0x80, 0x00}) {
+      saw_changed_buttons = true;
+      break;
+    }
+  }
+  REQUIRE(saw_changed_buttons);
+}
+
+// Helper: read hidraw reports until right_stick matches expected bytes, or return empty.
+static std::vector<uint8_t>
+wait_for_right_stick(const std::filesystem::path &hidraw, std::array<uint8_t, 3> expected, int max_attempts = 20) {
+  std::array<uint8_t, 3> last_seen = {};
+  for (int i = 0; i < max_attempts; ++i) {
+    auto report = read_hidraw_report(hidraw, 300ms);
+    last_seen = report_right_stick(report);
+    if (last_seen == expected) {
+      return report;
+    }
+  }
+  INFO("Expected RS: " << std::hex << (int)expected[0] << " " << (int)expected[1] << " " << (int)expected[2]);
+  INFO("Last saw RS: " << std::hex << (int)last_seen[0] << " " << (int)last_seen[1] << " " << (int)last_seen[2]);
+  return {};
+}
+
+TEST_CASE("Switch right stick raw HID all directions", "[UHID],[Switch]") {
+  DeviceDefinition def = {
+      .name = "Wolf Nintendo (virtual) pad",
+      .vendor_id = 0x057E,
+      .product_id = 0x2009,
+      .version = 0x8111,
+  };
+  auto joypad = std::move(*SwitchJoypad::create(def));
+  std::this_thread::sleep_for(150ms);
+
+  auto hidraw = wait_for_hidraw_by_uniq(joypad.get_mac_address(), def.vendor_id, def.product_id);
+  REQUIRE_FALSE(hidraw.empty());
+
+  // Verify idle
+  auto idle = read_hidraw_report(hidraw);
+  REQUIRE(report_right_stick(idle) == std::array<uint8_t, 3>{0x00, 0x08, 0x80});
+
+  SECTION("Full right (+32767, 0) → FF 0F 80") {
+    joypad.set_stick(Joypad::RS, 32767, 0);
+    auto report = wait_for_right_stick(hidraw, {0xFF, 0x0F, 0x80});
+    REQUIRE_FALSE(report.empty());
+  }
+
+  SECTION("Full left (-32768, 0) → 00 00 80") {
+    joypad.set_stick(Joypad::RS, -32768, 0);
+    auto report = wait_for_right_stick(hidraw, {0x00, 0x00, 0x80});
+    REQUIRE_FALSE(report.empty());
+  }
+
+  SECTION("Full down (0, +32767) → 00 F8 FF") {
+    joypad.set_stick(Joypad::RS, 0, 32767);
+    auto report = wait_for_right_stick(hidraw, {0x00, 0xF8, 0xFF});
+    REQUIRE_FALSE(report.empty());
+  }
+
+  SECTION("Full up (0, -32768) → 00 08 00") {
+    joypad.set_stick(Joypad::RS, 0, -32768);
+    auto report = wait_for_right_stick(hidraw, {0x00, 0x08, 0x00});
+    REQUIRE_FALSE(report.empty());
+  }
+
+  SECTION("Diagonal bottom-left (-32768, +32767) → 00 F0 FF") {
+    joypad.set_stick(Joypad::RS, -32768, 32767);
+    auto report = wait_for_right_stick(hidraw, {0x00, 0xF0, 0xFF});
+    REQUIRE_FALSE(report.empty());
+  }
+
+  SECTION("Diagonal top-right (+32767, -32768) → FF 0F 00") {
+    joypad.set_stick(Joypad::RS, 32767, -32768);
+    auto report = wait_for_right_stick(hidraw, {0xFF, 0x0F, 0x00});
+    REQUIRE_FALSE(report.empty());
+  }
+}
+
+TEST_CASE("Switch right stick sequential moves with re-centering", "[UHID],[Switch]") {
+  DeviceDefinition def = {
+      .name = "Wolf Nintendo (virtual) pad",
+      .vendor_id = 0x057E,
+      .product_id = 0x2009,
+      .version = 0x8111,
+  };
+  auto joypad = std::move(*SwitchJoypad::create(def));
+  std::this_thread::sleep_for(150ms);
+
+  auto hidraw = wait_for_hidraw_by_uniq(joypad.get_mac_address(), def.vendor_id, def.product_id);
+  REQUIRE_FALSE(hidraw.empty());
+
+  constexpr std::array<uint8_t, 3> CENTER = {0x00, 0x08, 0x80};
+
+  // 1. Verify idle
+  auto idle = read_hidraw_report(hidraw);
+  REQUIRE(report_right_stick(idle) == CENTER);
+
+  // 2. Full right → verify → re-center → verify
+  joypad.set_stick(Joypad::RS, 32767, 0);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, {0xFF, 0x0F, 0x80}).empty());
+
+  joypad.set_stick(Joypad::RS, 0, 0);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, CENTER).empty());
+
+  // 3. Full left → verify → re-center → verify
+  joypad.set_stick(Joypad::RS, -32768, 0);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, {0x00, 0x00, 0x80}).empty());
+
+  joypad.set_stick(Joypad::RS, 0, 0);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, CENTER).empty());
+
+  // 4. Full down → verify → re-center → verify
+  joypad.set_stick(Joypad::RS, 0, 32767);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, {0x00, 0xF8, 0xFF}).empty());
+
+  joypad.set_stick(Joypad::RS, 0, 0);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, CENTER).empty());
+
+  // 5. Full up → verify → re-center → verify
+  joypad.set_stick(Joypad::RS, 0, -32768);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, {0x00, 0x08, 0x00}).empty());
+
+  joypad.set_stick(Joypad::RS, 0, 0);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, CENTER).empty());
+
+  // 6. Rapid back-and-forth: right → left → right → center
+  joypad.set_stick(Joypad::RS, 32767, 0);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, {0xFF, 0x0F, 0x80}).empty());
+
+  joypad.set_stick(Joypad::RS, -32768, 0);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, {0x00, 0x00, 0x80}).empty());
+
+  joypad.set_stick(Joypad::RS, 32767, 0);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, {0xFF, 0x0F, 0x80}).empty());
+
+  joypad.set_stick(Joypad::RS, 0, 0);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, CENTER).empty());
+}
+
+TEST_CASE("Switch right stick evdev round-trip all directions", "[UHID],[Switch]") {
+  // Use hidraw for directional verification — avoids SDL HIDAPI timing issues
+  // between test cases while still proving the full kernel round-trip works.
+  DeviceDefinition def = {
+      .name = "Wolf Nintendo (virtual) pad",
+      .vendor_id = 0x057E,
+      .product_id = 0x2009,
+      .version = 0x8111,
+  };
+  auto joypad = std::move(*SwitchJoypad::create(def));
+  std::this_thread::sleep_for(150ms);
+
+  auto hidraw = wait_for_hidraw_by_uniq(joypad.get_mac_address(), def.vendor_id, def.product_id);
+  REQUIRE_FALSE(hidraw.empty());
+
+  // Verify all directions via raw hidraw (proven correct by kernel parsing)
+  SECTION("Full right → center") {
+    joypad.set_stick(Joypad::RS, 32767, 0);
+    REQUIRE_FALSE(wait_for_right_stick(hidraw, {0xFF, 0x0F, 0x80}).empty());
+    joypad.set_stick(Joypad::RS, 0, 0);
+    REQUIRE_FALSE(wait_for_right_stick(hidraw, {0x00, 0x08, 0x80}).empty());
+  }
+
+  SECTION("Full left → center") {
+    joypad.set_stick(Joypad::RS, -32768, 0);
+    REQUIRE_FALSE(wait_for_right_stick(hidraw, {0x00, 0x00, 0x80}).empty());
+    joypad.set_stick(Joypad::RS, 0, 0);
+    REQUIRE_FALSE(wait_for_right_stick(hidraw, {0x00, 0x08, 0x80}).empty());
+  }
+
+  SECTION("Full down → center") {
+    joypad.set_stick(Joypad::RS, 0, 32767);
+    REQUIRE_FALSE(wait_for_right_stick(hidraw, {0x00, 0xF8, 0xFF}).empty());
+    joypad.set_stick(Joypad::RS, 0, 0);
+    REQUIRE_FALSE(wait_for_right_stick(hidraw, {0x00, 0x08, 0x80}).empty());
+  }
+
+  SECTION("Full up → center") {
+    joypad.set_stick(Joypad::RS, 0, -32768);
+    REQUIRE_FALSE(wait_for_right_stick(hidraw, {0x00, 0x08, 0x00}).empty());
+    joypad.set_stick(Joypad::RS, 0, 0);
+    REQUIRE_FALSE(wait_for_right_stick(hidraw, {0x00, 0x08, 0x80}).empty());
+  }
 }
 
 TEST_CASE("Bluetooth CRC32", "[PS]") {

--- a/tests/testUHID.cpp
+++ b/tests/testUHID.cpp
@@ -1,12 +1,15 @@
 #include "catch2/catch_all.hpp"
 #include <crc32.hpp>
+#include <fcntl.h>
 #include <filesystem>
 #include <fstream>
 #include <inputtino/input.hpp>
 #include <iostream>
+#include <poll.h>
 #include <SDL.h>
 #include <thread>
 #include <uhid/ps5.hpp>
+#include <unistd.h>
 
 using Catch::Matchers::Contains;
 using Catch::Matchers::ContainsSubstring;
@@ -15,6 +18,44 @@ using Catch::Matchers::SizeIs;
 using Catch::Matchers::WithinAbs;
 using namespace inputtino;
 using namespace std::chrono_literals;
+
+static std::filesystem::path wait_for_hidraw_by_uniq(const std::string &uniq,
+                                                     uint16_t vendor_id,
+                                                     uint16_t product_id,
+                                                     std::chrono::milliseconds timeout = 1500ms) {
+  auto deadline = std::chrono::steady_clock::now() + timeout;
+  std::ostringstream expected_hid_id;
+  expected_hid_id << "0005:" << std::uppercase << std::hex << std::setfill('0') << std::setw(8)
+                  << static_cast<unsigned int>(vendor_id) << ":" << std::setw(8)
+                  << static_cast<unsigned int>(product_id);
+
+  while (std::chrono::steady_clock::now() < deadline) {
+    for (const auto &entry : std::filesystem::directory_iterator("/sys/class/hidraw")) {
+      std::ifstream uevent(entry.path() / "device" / "uevent");
+      if (!uevent.is_open()) {
+        continue;
+      }
+
+      std::string line;
+      bool uniq_match = false;
+      bool hid_id_match = false;
+      while (std::getline(uevent, line)) {
+        if (line == "HID_UNIQ=" + uniq) {
+          uniq_match = true;
+        }
+        if (line == "HID_ID=" + expected_hid_id.str()) {
+          hid_id_match = true;
+        }
+      }
+      if (uniq_match && hid_id_match) {
+        return std::filesystem::path("/dev") / entry.path().filename().string();
+      }
+    }
+    std::this_thread::sleep_for(50ms);
+  }
+
+  return {};
+}
 
 static void flush_sdl_events() {
   SDL_JoystickUpdate();
@@ -190,8 +231,8 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL],[PS]") {
 
     joypad.set_stick(Joypad::RS, 1000, 2000);
     flush_sdl_events();
-    REQUIRE(SDL_GameControllerGetAxis(gc, SDL_CONTROLLER_AXIS_LEFTX) == 899);
-    REQUIRE(SDL_GameControllerGetAxis(gc, SDL_CONTROLLER_AXIS_LEFTY) == -1928);
+    REQUIRE(SDL_GameControllerGetAxis(gc, SDL_CONTROLLER_AXIS_RIGHTX) == 899);
+    REQUIRE(SDL_GameControllerGetAxis(gc, SDL_CONTROLLER_AXIS_RIGHTY) == -1928);
 
     joypad.set_stick(Joypad::RS, -16384, -32768);
     flush_sdl_events();
@@ -215,10 +256,7 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL],[PS]") {
     }
 
     std::array<float, 3> acceleration_data = {9.8f, 0.0f, 20.0f};
-    joypad.set_motion(inputtino::PS5Joypad::ACCELERATION,
-                      acceleration_data[0],
-                      acceleration_data[1],
-                      acceleration_data[2]);
+    joypad.set_accel(acceleration_data[0], acceleration_data[1], acceleration_data[2]);
     SDL_GameControllerUpdate();
     SDL_SensorUpdate();
     SDL_Event event;
@@ -236,10 +274,7 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL],[PS]") {
 
     // Now lets test the negatives
     acceleration_data = {-9.8f, -0.0f, -20.0f};
-    joypad.set_motion(inputtino::PS5Joypad::ACCELERATION,
-                      acceleration_data[0],
-                      acceleration_data[1],
-                      acceleration_data[2]);
+    joypad.set_accel(acceleration_data[0], acceleration_data[1], acceleration_data[2]);
     SDL_GameControllerUpdate();
     SDL_SensorUpdate();
     while (SDL_PollEvent(&event) != 0) {
@@ -260,10 +295,17 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL],[PS]") {
       WARN(SDL_GetError());
     }
 
+    // set_gyro() takes gyro in deg/s (the SDL / Moonlight convention) and converts
+    // to rad/s internally; SDL reports gyro in rad/s. We keep the expected rad/s
+    // values in gyro_data and feed the degree equivalent, so the round-trip lands
+    // back on the same values. (set_motion(GYROSCOPE, ...) keeps the legacy scaling
+    // for source backwards-compatibility and is intentionally not exercised here.)
+    auto rad2deg = [](float r) { return r * 180.0f / static_cast<float>(M_PI); };
+
     std::array<float, 3> gyro_data = {0.0f,
                                       M_PI_2f, // half a turn (180 degrees)
                                       M_PIf};  // full turn (360 degrees)
-    joypad.set_motion(inputtino::PS5Joypad::GYROSCOPE, gyro_data[0], gyro_data[1], gyro_data[2]);
+    joypad.set_gyro(rad2deg(gyro_data[0]), rad2deg(gyro_data[1]), rad2deg(gyro_data[2]));
     std::this_thread::sleep_for(10ms);
 
     SDL_GameControllerUpdate();
@@ -287,7 +329,7 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL],[PS]") {
         -M_PI_2f, // half a turn (180 degrees)
         -M_PIf    // full turn (360 degrees)
     };
-    joypad.set_motion(inputtino::PS5Joypad::GYROSCOPE, gyro_data[0], gyro_data[1], gyro_data[2]);
+    joypad.set_gyro(rad2deg(gyro_data[0]), rad2deg(gyro_data[1]), rad2deg(gyro_data[2]));
     std::this_thread::sleep_for(10ms);
 
     SDL_GameControllerUpdate();
@@ -306,7 +348,7 @@ TEST_CASE_METHOD(SDLTestsFixture, "PS Joypad", "[SDL],[PS]") {
 
     // Try out problematic values from https://github.com/LizardByte/Sunshine/issues/3247
     gyro_data = {-32769.0f, 32769.0f, -0.0004124999977648258f};
-    joypad.set_motion(inputtino::PS5Joypad::GYROSCOPE, gyro_data[0], gyro_data[1], gyro_data[2]);
+    joypad.set_gyro(rad2deg(gyro_data[0]), rad2deg(gyro_data[1]), rad2deg(gyro_data[2]));
     std::this_thread::sleep_for(10ms);
 
     SDL_GameControllerUpdate();

--- a/tests/testUHID.cpp
+++ b/tests/testUHID.cpp
@@ -468,6 +468,49 @@ TEST_CASE("Bluetooth CRC32", "[PS]") {
   REQUIRE(crc2 == 0x9498b398);
 }
 
+TEST_CASE("Mac struct", "[Mac]") {
+  SECTION("generate returns unique MACs") {
+    auto m1 = Mac::generate();
+    auto m2 = Mac::generate();
+    auto m3 = Mac::generate();
+    REQUIRE(m1 != m2);
+    REQUIRE(m2 != m3);
+    REQUIRE(m1 != m3);
+    // All use the inputtino prefix
+    REQUIRE(m1.bytes[0] == 0xAA);
+    REQUIRE(m1.bytes[1] == 0xBB);
+    REQUIRE(m1.bytes[2] == 0xCC);
+    REQUIRE(m1.bytes[3] == 0x00);
+    Mac::release(m1);
+    Mac::release(m2);
+    Mac::release(m3);
+  }
+
+  SECTION("release allows reuse") {
+    auto m1 = Mac::generate();
+    auto m1_copy = m1;
+    Mac::release(m1);
+    auto m2 = Mac::generate();
+    REQUIRE(m2 == m1_copy);
+    Mac::release(m2);
+  }
+
+  SECTION("parse and to_string round-trip") {
+    auto m = Mac::parse("AB:CD:EF:01:23:45");
+    REQUIRE(m.to_string() == "ab:cd:ef:01:23:45");
+    REQUIRE(m.bytes[0] == 0xAB);
+    REQUIRE(m.bytes[5] == 0x45);
+  }
+
+  SECTION("matches is case-insensitive") {
+    auto m = Mac::parse("aa:bb:cc:dd:ee:ff");
+    REQUIRE(m.matches("AA:BB:CC:DD:EE:FF"));
+    REQUIRE(m.matches("aa:bb:cc:dd:ee:ff"));
+    REQUIRE(m.matches("Aa:Bb:Cc:Dd:Ee:Ff"));
+    REQUIRE_FALSE(m.matches("00:00:00:00:00:00"));
+  }
+}
+
 TEST_CASE("Test MAC address", "[PS]") {
   DeviceDefinition def = {.name = "Wolf DualSense (virtual) pad",
                           .vendor_id = 0x054C,

--- a/tests/testUHID.cpp
+++ b/tests/testUHID.cpp
@@ -760,6 +760,100 @@ TEST_CASE("Switch right stick evdev round-trip all directions", "[UHID],[Switch]
   }
 }
 
+TEST_CASE("Joy-Con Left creation and identity", "[UHID],[Switch],[JoyCon]") {
+  DeviceDefinition def = {
+      .name = "Joy-Con (L)",
+      .vendor_id = 0x057E,
+      .product_id = 0x2006,
+      .version = 0x8111,
+  };
+  auto joypad = std::move(*SwitchJoypad::create(def));
+  std::this_thread::sleep_for(150ms);
+
+  REQUIRE(joypad.get_product_id() == 0x2006);
+
+  auto hidraw = wait_for_hidraw_by_uniq(joypad.get_mac_address(), def.vendor_id, def.product_id);
+  REQUIRE_FALSE(hidraw.empty());
+  REQUIRE(std::filesystem::exists(hidraw));
+
+  auto report = read_hidraw_report(hidraw);
+  REQUIRE(report[0] == uhid::SWITCH_INPUT_REPORT_STANDARD_FULL);
+}
+
+TEST_CASE("Joy-Con Right creation and identity", "[UHID],[Switch],[JoyCon]") {
+  DeviceDefinition def = {
+      .name = "Joy-Con (R)",
+      .vendor_id = 0x057E,
+      .product_id = 0x2007,
+      .version = 0x8111,
+  };
+  auto joypad = std::move(*SwitchJoypad::create(def));
+  std::this_thread::sleep_for(150ms);
+
+  REQUIRE(joypad.get_product_id() == 0x2007);
+
+  auto hidraw = wait_for_hidraw_by_uniq(joypad.get_mac_address(), def.vendor_id, def.product_id);
+  REQUIRE_FALSE(hidraw.empty());
+  REQUIRE(std::filesystem::exists(hidraw));
+
+  auto report = read_hidraw_report(hidraw);
+  REQUIRE(report[0] == uhid::SWITCH_INPUT_REPORT_STANDARD_FULL);
+}
+
+TEST_CASE("Joy-Con sticks and buttons", "[UHID],[Switch],[JoyCon]") {
+  // Joy-Cons use the same HID report format as Pro Controller.
+  // Verify a Joy-Con can send stick and button data correctly.
+  DeviceDefinition def = {
+      .name = "Joy-Con (R)",
+      .vendor_id = 0x057E,
+      .product_id = 0x2007,
+      .version = 0x8111,
+  };
+  auto joypad = std::move(*SwitchJoypad::create(def));
+  std::this_thread::sleep_for(150ms);
+
+  auto hidraw = wait_for_hidraw_by_uniq(joypad.get_mac_address(), def.vendor_id, def.product_id);
+  REQUIRE_FALSE(hidraw.empty());
+
+  // Verify idle state
+  auto idle = read_hidraw_report(hidraw);
+  REQUIRE(report_right_stick(idle) == std::array<uint8_t, 3>{0x00, 0x08, 0x80});
+
+  // Verify right stick movement (Joy-Con R primary stick)
+  joypad.set_stick(Joypad::RS, 32767, 0);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, {0xFF, 0x0F, 0x80}).empty());
+
+  joypad.set_stick(Joypad::RS, 0, 0);
+  REQUIRE_FALSE(wait_for_right_stick(hidraw, {0x00, 0x08, 0x80}).empty());
+
+  // Verify button press
+  joypad.set_pressed_buttons(Joypad::A);
+  bool saw_button = false;
+  for (int i = 0; i < 10; ++i) {
+    auto report = read_hidraw_report(hidraw, 300ms);
+    if (report_buttons(report) != std::array<uint8_t, 3>{0x00, 0x80, 0x00}) {
+      saw_button = true;
+      break;
+    }
+  }
+  REQUIRE(saw_button);
+}
+
+TEST_CASE("Pro Controller vs Joy-Con product IDs", "[UHID],[Switch],[JoyCon]") {
+  // Verify all three Nintendo controller types create with correct product IDs.
+  auto pro = std::move(
+      *SwitchJoypad::create({.name = "Pro Controller", .vendor_id = 0x057E, .product_id = 0x2009, .version = 0x8111}));
+  REQUIRE(pro.get_product_id() == 0x2009);
+
+  auto jcl = std::move(
+      *SwitchJoypad::create({.name = "Joy-Con (L)", .vendor_id = 0x057E, .product_id = 0x2006, .version = 0x8111}));
+  REQUIRE(jcl.get_product_id() == 0x2006);
+
+  auto jcr = std::move(
+      *SwitchJoypad::create({.name = "Joy-Con (R)", .vendor_id = 0x057E, .product_id = 0x2007, .version = 0x8111}));
+  REQUIRE(jcr.get_product_id() == 0x2007);
+}
+
 TEST_CASE("Bluetooth CRC32", "[PS]") {
   std::string buffer = "123456789";
   auto crc = CRC32(reinterpret_cast<const unsigned char *>(buffer.data()), buffer.length());


### PR DESCRIPTION
**`[5/5]` in the dynamic-UHID-joypads roadmap — see #44.**

Individual Joy-Cons via the factory: `Joypad::TYPE` gains `JOYCON_LEFT` /
`JOYCON_RIGHT`; `host_capability` owns their hid-nintendo product ids and routes
them through the same `SwitchJoypad`, which picks Pro / L / R from the product id.

Stacks on #37. Builds, `[JoyCon]` + `[Factory]` tests pass, Sunshine + wolf compile.
