### PR TITLE
[1/5] Fix flaky pen-tablet test assertions

### DIFF
--- a/tests/testLibinput.cpp
+++ b/tests/testLibinput.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 using namespace inputtino;
+using Catch::Matchers::WithinAbs;
 using Catch::Matchers::WithinRel;
 using namespace std::chrono_literals;
 
@@ -345,8 +346,8 @@ TEST_CASE("virtual pen tablet", "[LIBINPUT]") {
         REQUIRE(libinput_event_tablet_tool_get_proximity_state(t_event) == LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_IN);
         REQUIRE(libinput_tablet_tool_get_type(libinput_event_tablet_tool_get_tool(t_event)) ==
                 LIBINPUT_TABLET_TOOL_TYPE_PEN);
-        REQUIRE(libinput_event_tablet_tool_get_distance(t_event) == 0.5);
-        REQUIRE(libinput_event_tablet_tool_get_pressure(t_event) == 0.0);
+        REQUIRE_THAT(libinput_event_tablet_tool_get_distance(t_event), WithinAbs(0.5, 0.01));
+        REQUIRE_THAT(libinput_event_tablet_tool_get_pressure(t_event), WithinAbs(0.0, 0.01));
         REQUIRE_THAT(libinput_event_tablet_tool_get_x_transformed(t_event, TARGET_W), WithinRel(TARGET_W * 0.1f, 0.5f));
         REQUIRE_THAT(libinput_event_tablet_tool_get_y_transformed(t_event, TARGET_H), WithinRel(TARGET_H * 0.2f, 0.5f));
         REQUIRE_THAT(libinput_event_tablet_tool_get_tilt_x(t_event), WithinRel(45, 0.1f));
@@ -380,8 +381,8 @@ TEST_CASE("virtual pen tablet", "[LIBINPUT]") {
       REQUIRE(libinput_event_tablet_tool_get_proximity_state(t_event) == LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_IN);
       REQUIRE(libinput_tablet_tool_get_type(libinput_event_tablet_tool_get_tool(t_event)) ==
               LIBINPUT_TABLET_TOOL_TYPE_PEN);
-      REQUIRE(libinput_event_tablet_tool_get_distance(t_event) == 1.0);
-      REQUIRE(libinput_event_tablet_tool_get_pressure(t_event) == 0.0);
+      REQUIRE_THAT(libinput_event_tablet_tool_get_distance(t_event), WithinAbs(1.0, 0.01));
+      REQUIRE_THAT(libinput_event_tablet_tool_get_pressure(t_event), WithinAbs(0.0, 0.01));
       REQUIRE(libinput_event_tablet_tool_get_tip_state(t_event) == LIBINPUT_TABLET_TOOL_TIP_UP);
     }
 


### PR DESCRIPTION
**`[1/5]` in the dynamic-UHID-joypads roadmap (see #44).**

A tiny, standalone test-stabilization: the pen-tablet libinput test compared
floating-point distance/pressure with `==`, which is flaky. Switch to Catch2's
`WithinAbs` matcher.

Independent of the rest of the stack — safe to merge any time.
