### PR TITLE
fix(touch): don't reuse an active MT slot when placing a new finger

### DIFF
--- a/src/uinput/include/inputtino/protected_types.hpp
+++ b/src/uinput/include/inputtino/protected_types.hpp
@@ -72,7 +72,8 @@ struct TouchScreenState {
    * Slots are numbered starting from 0 up to <number of currently connected fingers> (max: 4)
    *
    * The way it works:
-   * - first time a new finger_id arrives we'll create a new slot and call MT_TRACKING_ID = slot_number
+   * - first time a new finger_id arrives we'll assign it the lowest free slot
+   *   and call MT_TRACKING_ID = <a monotonically increasing contact id>
    * - we can keep updating ABS_X and ABS_Y as long as the finger_id stays the same
    * - if we want to update a different finger we'll have to call ABS_MT_SLOT = slot_number
    * - when a finger is released we'll call ABS_MT_SLOT = slot_number && MT_TRACKING_ID = -1
@@ -82,6 +83,8 @@ struct TouchScreenState {
    */
   /* The MT_SLOT we are currently updating */
   int current_slot = -1;
+  /* The MT_TRACKING_ID to assign to the next new contact */
+  int next_tracking_id = 0;
   /* A map of finger_id to MT_SLOT */
   std::map<int /* finger_id */, int /* MT_SLOT */> fingers;
 };
@@ -94,7 +97,8 @@ struct TrackpadState {
    * Slots are numbered starting from 0 up to <number of currently connected fingers> (max: 4)
    *
    * The way it works:
-   * - first time a new finger_id arrives we'll create a new slot and call MT_TRACKING_ID = slot_number
+   * - first time a new finger_id arrives we'll assign it the lowest free slot
+   *   and call MT_TRACKING_ID = <a monotonically increasing contact id>
    * - we can keep updating ABS_X and ABS_Y as long as the finger_id stays the same
    * - if we want to update a different finger we'll have to call ABS_MT_SLOT = slot_number
    * - when a finger is released we'll call ABS_MT_SLOT = slot_number && MT_TRACKING_ID = -1
@@ -104,8 +108,27 @@ struct TrackpadState {
    */
   /* The MT_SLOT we are currently updating */
   int current_slot = -1;
+  /* The MT_TRACKING_ID to assign to the next new contact */
+  int next_tracking_id = 0;
   /* A map of finger_id to MT_SLOT */
   std::map<int /* finger_id */, int /* MT_SLOT */> fingers;
 };
+
+/* Returns the lowest MT slot not currently assigned to any finger */
+static inline int first_free_mt_slot(const std::map<int, int> &fingers) {
+  int slot = 0;
+  auto is_taken = [&fingers](int candidate) {
+    for (const auto &finger : fingers) {
+      if (finger.second == candidate) {
+        return true;
+      }
+    }
+    return false;
+  };
+  while (is_taken(slot)) {
+    slot++;
+  }
+  return slot;
+}
 
 } // namespace inputtino

--- a/src/uinput/touchscreen.cpp
+++ b/src/uinput/touchscreen.cpp
@@ -98,10 +98,16 @@ void TouchScreen::place_finger(int finger_nr, float x, float y, float pressure, 
 
     if (_state->fingers.find(finger_nr) == _state->fingers.end()) {
       // Wow, a wild finger appeared!
-      auto finger_slot = _state->fingers.size() + 1;
+      // Pick the lowest free slot: fingers.size() + 1 would collide with a slot that's
+      // still in use after another finger has been released (ex: two fingers down,
+      // first one lifted and placed again)
+      auto finger_slot = first_free_mt_slot(_state->fingers);
+      auto tracking_id = _state->next_tracking_id;
+      _state->next_tracking_id = (_state->next_tracking_id + 1) % 65536;
       _state->fingers[finger_nr] = finger_slot;
       libevdev_uinput_write_event(ts, EV_ABS, ABS_MT_SLOT, finger_slot);
-      libevdev_uinput_write_event(ts, EV_ABS, ABS_MT_TRACKING_ID, finger_slot);
+      _state->current_slot = finger_slot;
+      libevdev_uinput_write_event(ts, EV_ABS, ABS_MT_TRACKING_ID, tracking_id);
     } else {
       // I already know this finger, let's check the slot
       auto finger_slot = _state->fingers[finger_nr];
@@ -125,12 +131,17 @@ void TouchScreen::place_finger(int finger_nr, float x, float y, float pressure, 
 
 void TouchScreen::release_finger(int finger_nr) {
   if (auto ts = this->_state->touch_screen.get()) {
-    auto finger_slot = _state->fingers[finger_nr];
+    auto finger = _state->fingers.find(finger_nr);
+    if (finger == _state->fingers.end()) {
+      // Unknown finger, releasing it would corrupt the state of another slot
+      return;
+    }
+    auto finger_slot = finger->second;
     if (_state->current_slot != finger_slot) {
       libevdev_uinput_write_event(ts, EV_ABS, ABS_MT_SLOT, finger_slot);
-      _state->current_slot = -1;
+      _state->current_slot = finger_slot;
     }
-    _state->fingers.erase(finger_nr);
+    _state->fingers.erase(finger);
     libevdev_uinput_write_event(ts, EV_ABS, ABS_MT_TRACKING_ID, -1);
 
     libevdev_uinput_write_event(ts, EV_SYN, SYN_REPORT, 0);

--- a/src/uinput/trackpad.cpp
+++ b/src/uinput/trackpad.cpp
@@ -105,10 +105,16 @@ void Trackpad::place_finger(int finger_nr, float x, float y, float pressure, int
 
     if (_state->fingers.find(finger_nr) == _state->fingers.end()) {
       // Wow, a wild finger appeared!
-      auto finger_slot = _state->fingers.size() + 1;
+      // Pick the lowest free slot: fingers.size() + 1 would collide with a slot that's
+      // still in use after another finger has been released (ex: two fingers down,
+      // first one lifted and placed again)
+      auto finger_slot = first_free_mt_slot(_state->fingers);
+      auto tracking_id = _state->next_tracking_id;
+      _state->next_tracking_id = (_state->next_tracking_id + 1) % 65536;
       _state->fingers[finger_nr] = finger_slot;
       libevdev_uinput_write_event(touchpad, EV_ABS, ABS_MT_SLOT, finger_slot);
-      libevdev_uinput_write_event(touchpad, EV_ABS, ABS_MT_TRACKING_ID, finger_slot);
+      _state->current_slot = finger_slot;
+      libevdev_uinput_write_event(touchpad, EV_ABS, ABS_MT_TRACKING_ID, tracking_id);
       auto nr_fingers = _state->fingers.size();
       { // Update number of fingers pressed
         if (nr_fingers == 1) {
@@ -151,12 +157,17 @@ void Trackpad::place_finger(int finger_nr, float x, float y, float pressure, int
 
 void Trackpad::release_finger(int finger_nr) {
   if (auto touchpad = this->_state->trackpad.get()) {
-    auto finger_slot = _state->fingers[finger_nr];
+    auto finger = _state->fingers.find(finger_nr);
+    if (finger == _state->fingers.end()) {
+      // Unknown finger, releasing it would corrupt the state of another slot
+      return;
+    }
+    auto finger_slot = finger->second;
     if (_state->current_slot != finger_slot) {
       libevdev_uinput_write_event(touchpad, EV_ABS, ABS_MT_SLOT, finger_slot);
-      _state->current_slot = -1;
+      _state->current_slot = finger_slot;
     }
-    _state->fingers.erase(finger_nr);
+    _state->fingers.erase(finger);
     libevdev_uinput_write_event(touchpad, EV_ABS, ABS_MT_TRACKING_ID, -1);
     auto nr_fingers = _state->fingers.size();
     { // Update number of fingers pressed

--- a/tests/testLibinput.cpp
+++ b/tests/testLibinput.cpp
@@ -241,7 +241,7 @@ TEST_CASE("virtual touch screen", "[LIBINPUT]") {
         event = get_event(li);
         REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_TOUCH_DOWN);
         auto t_event = libinput_event_get_touch_event(event.get());
-        REQUIRE(libinput_event_touch_get_slot(t_event) == 1);
+        REQUIRE(libinput_event_touch_get_slot(t_event) == 0);
         REQUIRE_THAT(libinput_event_touch_get_x_transformed(t_event, TARGET_WIDTH),
                      WithinRel(TARGET_WIDTH * 0.1f, 0.5f));
         REQUIRE_THAT(libinput_event_touch_get_y_transformed(t_event, TARGET_HEIGHT),
@@ -255,7 +255,7 @@ TEST_CASE("virtual touch screen", "[LIBINPUT]") {
         event = get_event(li);
         REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_TOUCH_DOWN);
         auto t_event = libinput_event_get_touch_event(event.get());
-        REQUIRE(libinput_event_touch_get_slot(t_event) == 2);
+        REQUIRE(libinput_event_touch_get_slot(t_event) == 1);
         REQUIRE_THAT(libinput_event_touch_get_x_transformed(t_event, TARGET_WIDTH),
                      WithinRel(TARGET_WIDTH * 0.2f, 0.5f));
         REQUIRE_THAT(libinput_event_touch_get_y_transformed(t_event, TARGET_HEIGHT),
@@ -269,7 +269,46 @@ TEST_CASE("virtual touch screen", "[LIBINPUT]") {
         event = get_event(li);
         REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_TOUCH_UP);
         auto t_event = libinput_event_get_touch_event(event.get());
+        REQUIRE(libinput_event_touch_get_slot(t_event) == 0);
+        event = get_event(li);
+        REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_TOUCH_FRAME);
+    }
+
+    { // Place the first finger again while the second is still down:
+      // it must get its own free slot back, not collide with the second finger's slot
+        touch.place_finger(0, 0.3, 0.3, 0.3, 0);
+        event = get_event(li);
+        REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_TOUCH_DOWN);
+        auto t_event = libinput_event_get_touch_event(event.get());
+        REQUIRE(libinput_event_touch_get_slot(t_event) == 0);
+        REQUIRE_THAT(libinput_event_touch_get_x_transformed(t_event, TARGET_WIDTH),
+                     WithinRel(TARGET_WIDTH * 0.3f, 0.5f));
+        REQUIRE_THAT(libinput_event_touch_get_y_transformed(t_event, TARGET_HEIGHT),
+                     WithinRel(TARGET_HEIGHT * 0.3f, 0.5f));
+        event = get_event(li);
+        REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_TOUCH_FRAME);
+    }
+
+    { // Move the second finger: it must still be tracked in its own slot
+        touch.place_finger(1, 0.25, 0.25, 0.3, 0);
+        event = get_event(li);
+        REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_TOUCH_MOTION);
+        auto t_event = libinput_event_get_touch_event(event.get());
         REQUIRE(libinput_event_touch_get_slot(t_event) == 1);
+        REQUIRE_THAT(libinput_event_touch_get_x_transformed(t_event, TARGET_WIDTH),
+                     WithinRel(TARGET_WIDTH * 0.25f, 0.5f));
+        REQUIRE_THAT(libinput_event_touch_get_y_transformed(t_event, TARGET_HEIGHT),
+                     WithinRel(TARGET_HEIGHT * 0.25f, 0.5f));
+        event = get_event(li);
+        REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_TOUCH_FRAME);
+    }
+
+    { // Lift first finger again
+        touch.release_finger(0);
+        event = get_event(li);
+        REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_TOUCH_UP);
+        auto t_event = libinput_event_get_touch_event(event.get());
+        REQUIRE(libinput_event_touch_get_slot(t_event) == 0);
         event = get_event(li);
         REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_TOUCH_FRAME);
     }
@@ -279,7 +318,7 @@ TEST_CASE("virtual touch screen", "[LIBINPUT]") {
         event = get_event(li);
         REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_TOUCH_UP);
         auto t_event = libinput_event_get_touch_event(event.get());
-        REQUIRE(libinput_event_touch_get_slot(t_event) == 2);
+        REQUIRE(libinput_event_touch_get_slot(t_event) == 1);
         event = get_event(li);
         REQUIRE(libinput_event_get_type(event.get()) == LIBINPUT_EVENT_TOUCH_FRAME);
     }


### PR DESCRIPTION
## Problem

While streaming a game from Sunshine to an Android device with Moonlight (touch passthrough), multi-touch gestures would occasionally glitch: two distinct fingers were treated as the same contact. With two fingers down, lifting one and placing it again made both fingers share a single MT slot — their coordinates alternated inside one contact, so the remaining finger appeared to "teleport" between the two positions.

## Root cause chain

1. **Slot allocation** (`TouchScreen::place_finger()` / `Trackpad::place_finger()`): a new finger was assigned the slot `fingers.size() + 1`. This is only correct when fingers are released in reverse order of placement. Sequence that breaks it: place finger A → slot 1, place finger B → slot 2, release A (`fingers.size()` is now 1), place A again → slot `1 + 1 = 2` — **the same slot finger B is still using**. Two `finger_id`s now map to one MT slot.

2. **Tracking ID reuse**: `ABS_MT_TRACKING_ID` was set to the slot number itself. In the evdev MT protocol the tracking id must uniquely identify a contact for its lifetime; reusing slot numbers as tracking ids means a re-placed finger can resurrect the identity of a previous contact instead of starting a new one.

3. **`current_slot` desync**: when a new finger selected its slot via `ABS_MT_SLOT`, `current_slot` was not updated, so a following event for another finger could skip the `ABS_MT_SLOT` write and land in the wrong slot. `release_finger()` also reset `current_slot` to `-1` after emitting `ABS_MT_SLOT`, even though the kernel's slot state remained at the released slot.

4. **`release_finger()` on unknown ids**: it used `_state->fingers[finger_nr]`, so releasing a finger id that was never placed default-constructed an entry mapping it to slot 0 and emitted `MT_TRACKING_ID = -1` there — killing an unrelated active contact.

`Trackpad` shared the exact same allocation logic, so it had the same bug.

## Fix

- Assign new contacts the **lowest free MT slot** (`first_free_mt_slot()`) instead of `fingers.size() + 1`. As a side effect slots are now 0-based, matching the evdev convention.
- Use a **monotonically increasing `ABS_MT_TRACKING_ID`** (wrapping at 65536) instead of reusing the slot number, so every new contact has a unique identity.
- Keep `current_slot` in sync: set it when a new contact selects its slot, and track the actual kernel slot state in `release_finger()` instead of resetting to `-1`.
- `release_finger()` now ignores unknown finger ids instead of implicitly mapping them to slot 0 and corrupting another contact.
- Apply all of the above to both `TouchScreen` and `Trackpad`.

## Verified

- Extended `tests/testLibinput.cpp` to cover the exact failure sequence: two fingers down, first one lifted and placed again — it must get its own free slot back (slot 0) while the second finger keeps being tracked in its own slot (slot 1). All libinput tests pass.
- Recompiled Sunshine against patched inputtino and reproduced the original scenario from an Android phone over Moonlight: repeated lift-and-replace multi-touch gestures no longer merge contacts, both fingers track correctly.