### PR TITLE
fix: honor physical paths for uinput devices

### DIFF
--- a/src/uinput/include/inputtino/protected_types.hpp
+++ b/src/uinput/include/inputtino/protected_types.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <cstring>
+#include <fcntl.h>
 #include <inputtino/input.hpp>
 #include <iostream>
 #include <libevdev/libevdev-uinput.h>
 #include <libevdev/libevdev.h>
+#include <linux/uinput.h>
+#include <sys/ioctl.h>
 #include <thread>
 #include <unistd.h>
 
@@ -12,6 +15,43 @@ namespace inputtino {
 
 using libevdev_uinput_ptr = std::shared_ptr<libevdev_uinput>;
 using libevdev_event_ptr = std::shared_ptr<input_event>;
+
+static Result<libevdev_uinput_ptr> create_uinput_device(libevdev *dev, const DeviceDefinition &device) {
+  int uinput_fd = LIBEVDEV_UINPUT_OPEN_MANAGED;
+  bool owns_uinput_fd = false;
+
+  if (!device.device_phys.empty()) {
+    uinput_fd = open("/dev/uinput", O_RDWR | O_NONBLOCK);
+    if (uinput_fd < 0) {
+      return Error("Failed to open /dev/uinput: " + std::string(strerror(errno)));
+    }
+    owns_uinput_fd = true;
+
+    if (ioctl(uinput_fd, UI_SET_PHYS, device.device_phys.c_str()) < 0) {
+      const auto error = "Failed to set uinput physical path: " + std::string(strerror(errno));
+      close(uinput_fd);
+      return Error(error);
+    }
+  }
+
+  libevdev_uinput *uidev;
+  const auto err = libevdev_uinput_create_from_device(dev, uinput_fd, &uidev);
+  if (err != 0) {
+    if (owns_uinput_fd) {
+      close(uinput_fd);
+    }
+    return Error(strerror(-err));
+  }
+
+  if (!owns_uinput_fd) {
+    return libevdev_uinput_ptr{uidev, ::libevdev_uinput_destroy};
+  }
+
+  return libevdev_uinput_ptr{uidev, [uinput_fd](libevdev_uinput *device) {
+                               libevdev_uinput_destroy(device);
+                               close(uinput_fd);
+                             }};
+}
 
 /**
  * Given a uinput fd will read all queued events available at this time up to max_events

--- a/src/uinput/joypad_nintendo.cpp
+++ b/src/uinput/joypad_nintendo.cpp
@@ -23,7 +23,6 @@ std::vector<std::string> SwitchJoypad::get_nodes() const {
 
 Result<libevdev_uinput_ptr> create_nintendo_controller(const DeviceDefinition &device) {
   libevdev *dev = libevdev_new();
-  libevdev_uinput *uidev;
 
   libevdev_set_name(dev, device.name.c_str());
   libevdev_set_id_vendor(dev, device.vendor_id);
@@ -70,13 +69,9 @@ Result<libevdev_uinput_ptr> create_nintendo_controller(const DeviceDefinition &d
   libevdev_enable_event_code(dev, EV_FF, FF_RAMP, nullptr);
   libevdev_enable_event_code(dev, EV_FF, FF_GAIN, nullptr);
 
-  auto err = libevdev_uinput_create_from_device(dev, LIBEVDEV_UINPUT_OPEN_MANAGED, &uidev);
+  auto result = create_uinput_device(dev, device);
   libevdev_free(dev);
-  if (err != 0) {
-    return Error(strerror(-err));
-  }
-
-  return libevdev_uinput_ptr{uidev, ::libevdev_uinput_destroy};
+  return result;
 }
 
 SwitchJoypad::SwitchJoypad() : _state(std::make_shared<SwitchJoypadState>()) {}

--- a/src/uinput/joypad_ps.cpp
+++ b/src/uinput/joypad_ps.cpp
@@ -22,7 +22,6 @@ std::vector<std::string> PS5Joypad::get_nodes() const {
 
 Result<libevdev_uinput_ptr> create_ps_controller(const DeviceDefinition &device) {
   libevdev *dev = libevdev_new();
-  libevdev_uinput *uidev;
 
   libevdev_set_name(dev, device.name.c_str());
   libevdev_set_id_vendor(dev, device.vendor_id);
@@ -70,13 +69,9 @@ Result<libevdev_uinput_ptr> create_ps_controller(const DeviceDefinition &device)
   libevdev_enable_event_code(dev, EV_FF, FF_RAMP, nullptr);
   libevdev_enable_event_code(dev, EV_FF, FF_GAIN, nullptr);
 
-  auto err = libevdev_uinput_create_from_device(dev, LIBEVDEV_UINPUT_OPEN_MANAGED, &uidev);
+  auto result = create_uinput_device(dev, device);
   libevdev_free(dev);
-  if (err != 0) {
-    return Error(strerror(-err));
-  }
-
-  return libevdev_uinput_ptr{uidev, ::libevdev_uinput_destroy};
+  return result;
 }
 
 PS5Joypad::PS5Joypad(uint16_t vendor_id, std::array<unsigned char, 6> mac_address) : _state(std::make_shared<PS5JoypadState>()) {

--- a/src/uinput/joypad_xbox.cpp
+++ b/src/uinput/joypad_xbox.cpp
@@ -22,7 +22,6 @@ std::vector<std::string> XboxOneJoypad::get_nodes() const {
 
 Result<libevdev_uinput_ptr> create_xbox_controller(const DeviceDefinition &device) {
   libevdev *dev = libevdev_new();
-  libevdev_uinput *uidev;
 
   libevdev_set_name(dev, device.name.c_str());
   libevdev_set_id_vendor(dev, device.vendor_id);
@@ -67,13 +66,9 @@ Result<libevdev_uinput_ptr> create_xbox_controller(const DeviceDefinition &devic
   libevdev_enable_event_code(dev, EV_FF, FF_RAMP, nullptr);
   libevdev_enable_event_code(dev, EV_FF, FF_GAIN, nullptr);
 
-  auto err = libevdev_uinput_create_from_device(dev, LIBEVDEV_UINPUT_OPEN_MANAGED, &uidev);
+  auto result = create_uinput_device(dev, device);
   libevdev_free(dev);
-  if (err != 0) {
-    return Error(strerror(-err));
-  }
-
-  return libevdev_uinput_ptr{uidev, ::libevdev_uinput_destroy};
+  return result;
 }
 
 XboxOneJoypad::XboxOneJoypad() : _state(std::make_shared<XboxOneJoypadState>()) {}

--- a/src/uinput/keyboard.cpp
+++ b/src/uinput/keyboard.cpp
@@ -22,7 +22,6 @@ std::vector<std::string> Keyboard::get_nodes() const {
 
 Result<libevdev_uinput_ptr> create_keyboard(const DeviceDefinition &device) {
   auto dev = libevdev_new();
-  libevdev_uinput *uidev;
 
   libevdev_set_name(dev, device.name.c_str());
   libevdev_set_id_vendor(dev, device.vendor_id);
@@ -37,13 +36,9 @@ Result<libevdev_uinput_ptr> create_keyboard(const DeviceDefinition &device) {
     libevdev_enable_event_code(dev, EV_KEY, ev.second.linux_code, nullptr);
   }
 
-  auto err = libevdev_uinput_create_from_device(dev, LIBEVDEV_UINPUT_OPEN_MANAGED, &uidev);
+  auto result = create_uinput_device(dev, device);
   libevdev_free(dev);
-  if (err != 0) {
-    return Error(strerror(-err));
-  }
-
-  return libevdev_uinput_ptr{uidev, ::libevdev_uinput_destroy};
+  return result;
 }
 
 static std::optional<keyboard::KEY_MAP> press_btn(libevdev_uinput *kb, short key_code) {

--- a/src/uinput/mouse.cpp
+++ b/src/uinput/mouse.cpp
@@ -24,7 +24,6 @@ constexpr int ABS_MAX_HEIGHT = 12000;
 
 static Result<libevdev_uinput_ptr> create_mouse(const DeviceDefinition &device) {
   libevdev *dev = libevdev_new();
-  libevdev_uinput *uidev;
 
   libevdev_set_name(dev, device.name.c_str());
   libevdev_set_id_vendor(dev, device.vendor_id);
@@ -54,18 +53,13 @@ static Result<libevdev_uinput_ptr> create_mouse(const DeviceDefinition &device) 
   libevdev_enable_event_type(dev, EV_MSC);
   libevdev_enable_event_code(dev, EV_MSC, MSC_SCAN, nullptr);
 
-  auto err = libevdev_uinput_create_from_device(dev, LIBEVDEV_UINPUT_OPEN_MANAGED, &uidev);
+  auto result = create_uinput_device(dev, device);
   libevdev_free(dev);
-  if (err != 0) {
-    return Error(strerror(-err));
-  }
-
-  return libevdev_uinput_ptr{uidev, ::libevdev_uinput_destroy};
+  return result;
 }
 
 static Result<libevdev_uinput_ptr> create_mouse_abs(const DeviceDefinition &device) {
   libevdev *dev = libevdev_new();
-  libevdev_uinput *uidev;
 
   libevdev_set_name(dev, (device.name + " (absolute)").c_str());
   libevdev_set_id_vendor(dev, device.vendor_id);
@@ -103,13 +97,9 @@ static Result<libevdev_uinput_ptr> create_mouse_abs(const DeviceDefinition &devi
   absinfo.maximum = ABS_MAX_HEIGHT;
   libevdev_enable_event_code(dev, EV_ABS, ABS_Y, &absinfo);
 
-  auto err = libevdev_uinput_create_from_device(dev, LIBEVDEV_UINPUT_OPEN_MANAGED, &uidev);
+  auto result = create_uinput_device(dev, device);
   libevdev_free(dev);
-  if (err != 0) {
-    return Error(strerror(-err));
-  }
-
-  return libevdev_uinput_ptr{uidev, ::libevdev_uinput_destroy};
+  return result;
 }
 
 Mouse::Mouse() : _state(std::make_shared<MouseState>()) {}

--- a/src/uinput/pentablet.cpp
+++ b/src/uinput/pentablet.cpp
@@ -29,7 +29,6 @@ static constexpr int RESOLUTION = 28;
 
 Result<libevdev_uinput_ptr> create_tablet(const DeviceDefinition &device) {
   libevdev *dev = libevdev_new();
-  libevdev_uinput *uidev;
 
   libevdev_set_name(dev, device.name.c_str());
   libevdev_set_id_vendor(dev, device.vendor_id);
@@ -67,13 +66,9 @@ Result<libevdev_uinput_ptr> create_tablet(const DeviceDefinition &device) {
   // https://docs.kernel.org/input/event-codes.html#tablets
   libevdev_enable_property(dev, INPUT_PROP_POINTER);
   libevdev_enable_property(dev, INPUT_PROP_DIRECT);
-  auto err = libevdev_uinput_create_from_device(dev, LIBEVDEV_UINPUT_OPEN_MANAGED, &uidev);
+  auto result = create_uinput_device(dev, device);
   libevdev_free(dev);
-  if (err != 0) {
-    return Error(strerror(-err));
-  }
-
-  return libevdev_uinput_ptr{uidev, ::libevdev_uinput_destroy};
+  return result;
 }
 
 PenTablet::PenTablet() : _state(std::make_shared<PenTabletState>()) {}

--- a/src/uinput/touchscreen.cpp
+++ b/src/uinput/touchscreen.cpp
@@ -23,7 +23,6 @@ static constexpr int PRESSURE_MAX = 253;
 
 Result<libevdev_uinput_ptr> create_touch_screen(const DeviceDefinition &device) {
   libevdev *dev = libevdev_new();
-  libevdev_uinput *uidev;
 
   libevdev_set_name(dev, device.name.c_str());
   libevdev_set_id_vendor(dev, device.vendor_id);
@@ -62,13 +61,9 @@ Result<libevdev_uinput_ptr> create_touch_screen(const DeviceDefinition &device) 
   // https://docs.kernel.org/input/event-codes.html#touchscreens
   libevdev_enable_property(dev, INPUT_PROP_DIRECT);
 
-  auto err = libevdev_uinput_create_from_device(dev, LIBEVDEV_UINPUT_OPEN_MANAGED, &uidev);
+  auto result = create_uinput_device(dev, device);
   libevdev_free(dev);
-  if (err != 0) {
-    return Error(strerror(-err));
-  }
-
-  return libevdev_uinput_ptr{uidev, ::libevdev_uinput_destroy};
+  return result;
 }
 
 TouchScreen::TouchScreen() : _state(std::make_shared<TouchScreenState>()) {}

--- a/src/uinput/trackpad.cpp
+++ b/src/uinput/trackpad.cpp
@@ -24,7 +24,6 @@ static constexpr int PRESSURE_MAX = 253;
 
 Result<libevdev_uinput_ptr> create_trackpad(const DeviceDefinition &device) {
   libevdev *dev = libevdev_new();
-  libevdev_uinput *uidev;
 
   libevdev_set_name(dev, device.name.c_str());
   libevdev_set_id_vendor(dev, device.vendor_id);
@@ -70,13 +69,9 @@ Result<libevdev_uinput_ptr> create_trackpad(const DeviceDefinition &device) {
   libevdev_enable_property(dev, INPUT_PROP_POINTER);
   libevdev_enable_property(dev, INPUT_PROP_BUTTONPAD);
 
-  auto err = libevdev_uinput_create_from_device(dev, LIBEVDEV_UINPUT_OPEN_MANAGED, &uidev);
+  auto result = create_uinput_device(dev, device);
   libevdev_free(dev);
-  if (err != 0) {
-    return Error(strerror(-err));
-  }
-
-  return libevdev_uinput_ptr{uidev, ::libevdev_uinput_destroy};
+  return result;
 }
 
 Trackpad::Trackpad() : _state(std::make_shared<TrackpadState>()) {}

--- a/tests/libinput.h
+++ b/tests/libinput.h
@@ -1,12 +1,14 @@
 #pragma once
 
+#include <fcntl.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
 #include <libinput.h>
 #include <memory>
 #include <string>
-#include <vector>
 #include <unistd.h>
-#include <fcntl.h>
-#include <iostream>
+#include <vector>
 
 static int open_restricted(const char *path, int flags, void *user_data) {
     int fd = open(path, flags);
@@ -48,4 +50,12 @@ static std::shared_ptr<libinput_event> get_event(std::shared_ptr<libinput> li) {
     libinput_dispatch(li.get());
     struct libinput_event *event = libinput_get_event(li.get());
     return std::shared_ptr<libinput_event>(event, [](libinput_event *event) { libinput_event_destroy(event); });
+}
+
+static std::string get_device_phys(const std::string &node) {
+  const auto event_name = std::filesystem::path(node).filename();
+  std::ifstream phys_file(std::filesystem::path("/sys/class/input") / event_name / "device/phys");
+  std::string phys;
+  std::getline(phys_file, phys);
+  return phys;
 }

--- a/tests/testLibinput.cpp
+++ b/tests/testLibinput.cpp
@@ -16,6 +16,48 @@ using namespace std::chrono_literals;
  * TESTS
  */
 
+TEST_CASE("virtual devices preserve the configured physical path", "[LIBINPUT]") {
+  const std::string expected_phys = "inputtino/test/device";
+  const DeviceDefinition device = {
+      .name = "inputtino physical path test",
+      .vendor_id = 0xAB00,
+      .product_id = 0xAB01,
+      .version = 0xAB00,
+      .device_phys = expected_phys,
+  };
+
+  SECTION("keyboard") {
+    auto keyboard = std::move(*Keyboard::create(device));
+    REQUIRE(keyboard.get_nodes().size() == 1);
+    REQUIRE(get_device_phys(keyboard.get_nodes()[0]) == expected_phys);
+  }
+
+  SECTION("relative and absolute mouse") {
+    auto mouse = std::move(*Mouse::create(device));
+    REQUIRE(mouse.get_nodes().size() == 2);
+    REQUIRE(get_device_phys(mouse.get_nodes()[0]) == expected_phys);
+    REQUIRE(get_device_phys(mouse.get_nodes()[1]) == expected_phys);
+  }
+
+  SECTION("touch screen") {
+    auto touch_screen = std::move(*TouchScreen::create(device));
+    REQUIRE(touch_screen.get_nodes().size() == 1);
+    REQUIRE(get_device_phys(touch_screen.get_nodes()[0]) == expected_phys);
+  }
+
+  SECTION("pen tablet") {
+    auto pen_tablet = std::move(*PenTablet::create(device));
+    REQUIRE(pen_tablet.get_nodes().size() == 1);
+    REQUIRE(get_device_phys(pen_tablet.get_nodes()[0]) == expected_phys);
+  }
+
+  SECTION("trackpad") {
+    auto trackpad = std::move(*Trackpad::create(device));
+    REQUIRE(trackpad.get_nodes().size() == 1);
+    REQUIRE(get_device_phys(trackpad.get_nodes()[0]) == expected_phys);
+  }
+}
+
 TEST_CASE("virtual keyboard", "[LIBINPUT]") {
     auto kb = std::move(*Keyboard::create());
     auto li = create_libinput_context(kb.get_nodes());


### PR DESCRIPTION
## Summary

- apply non-empty `DeviceDefinition::device_phys` values through the kernel `UI_SET_PHYS` ioctl before creating libevdev uinput devices
- share the explicit uinput file-descriptor setup and cleanup across keyboard, relative and absolute mouse, touchscreen, pen tablet, trackpad, and uinput joypads
- verify the configured physical path through the sysfs attribute consumed by udev

## Root cause

The public device definition exposes `device_phys`, and callers already populate it, but inputtino's uinput implementations only applied the name and numeric identity fields. Only the UHID DualSense path consumed the physical path. Consumers that rely on udev matching by `phys` therefore could not classify uinput devices as intended.

This was observed in papi-ux/polaris#494, where private-session keyboard and pointer devices remained on the host seat because their configured isolation marker never reached the kernel device.

`libevdev_set_phys()` is not sufficient here. It updates libevdev's in-memory descriptor, while libevdev documents virtual uinput devices as having no libevdev physical location. The working path opens `/dev/uinput`, applies `UI_SET_PHYS` before `UI_DEV_CREATE`, passes that descriptor into libevdev, and closes it after destroying the device.

## Compatibility

Empty physical paths retain the existing libevdev-managed descriptor path. Non-empty paths now honor the existing public field. Failure to open `/dev/uinput` or apply the requested physical path fails device creation instead of silently creating a device with the wrong identity.

## Validation

- GCC 16 Linux build with C and C++ bindings: pass
- source-only RED using the current upstream `stable` library: all five device sections fail because the sysfs `phys` value is empty, return code 5
- GREEN using this branch: 11 of 11 assertions pass for keyboard, both mouse nodes, touchscreen, pen tablet, and trackpad
- Polaris udev smoke: keyboard plus relative and absolute mouse nodes all expose the requested marker, receive `ID_SEAT=seat-polaris`, group `input`, and mode `0660`; all nodes disappear after teardown
- changed-line `clang-format` check: pass
- full CTest comparison: both the upstream baseline and this branch pass 15 of 21 tests on the validation host; the remaining SDL identity, event-order, and UHID timing failures are host-dependent and occur on both sides

This PR remains draft pending maintainer review.
