### PR TITLE
feat(joypad): PS5 joypads over USB + acknowledge UHID set-report requests

### DIFF
--- a/bindings/rust/inputtino/src/common.rs
+++ b/bindings/rust/inputtino/src/common.rs
@@ -96,12 +96,20 @@ pub(crate) fn make_device<T>(
     f: CreateDeviceFn<T>,
     definition: &DeviceDefinition,
 ) -> Result<*mut T, InputtinoError> {
+    make_device_with(definition, |def, eh| unsafe { f(def, eh) })
+}
+
+/// Like [`make_device`], for constructors that take extra arguments.
+pub(crate) fn make_device_with<T>(
+    definition: &DeviceDefinition,
+    f: impl FnOnce(*const InputtinoDeviceDefinition, *const InputtinoErrorHandler) -> *mut T,
+) -> Result<*mut T, InputtinoError> {
     let mut error_str = std::ffi::CString::default();
     let error_handler = InputtinoErrorHandler {
         eh: Some(error_handler_fn),
         user_data: &mut error_str as *mut _ as *mut std::ffi::c_void,
     };
-    let device = unsafe { f(&definition.def, &error_handler) };
+    let device = f(&definition.def, &error_handler);
     if device.is_null() {
         let error_msg = error_str.to_string_lossy();
         Err(InputtinoError::Generic(format!(

--- a/bindings/rust/inputtino/src/joypad_ps5.rs
+++ b/bindings/rust/inputtino/src/joypad_ps5.rs
@@ -2,15 +2,16 @@ use inputtino_sys::{inputtino_joypad_ps5_place_finger, inputtino_joypad_ps5_rele
 use std::ffi::{c_int, c_void};
 use std::path::PathBuf;
 
-use crate::common::{get_nodes, make_device, DeviceDefinition};
+use crate::common::{get_nodes, make_device, make_device_with, DeviceDefinition};
 use crate::sys::{
-    inputtino_joypad_ps5_create, inputtino_joypad_ps5_destroy, inputtino_joypad_ps5_get_nodes,
+    inputtino_joypad_ps5_create, inputtino_joypad_ps5_create_with_connection,
+    inputtino_joypad_ps5_destroy, inputtino_joypad_ps5_get_nodes,
     inputtino_joypad_ps5_set_on_led, inputtino_joypad_ps5_set_on_rumble,
     inputtino_joypad_ps5_set_pressed_buttons, inputtino_joypad_ps5_set_stick,
     inputtino_joypad_ps5_set_triggers, inputtino_joypad_ps5_set_motion,
     inputtino_joypad_ps5_set_battery, inputtino_joypad_ps5_set_on_trigger_effect,
 };
-use crate::{BatteryState, InputtinoError, JoypadMotionType, JoypadStickPosition};
+use crate::{BatteryState, InputtinoError, JoypadMotionType, JoypadStickPosition, PS5Connection};
 
 /// Emulated PlayStation 5's DualSense joypad.
 pub struct PS5Joypad {
@@ -41,12 +42,29 @@ impl PS5Joypad {
     /// let device = inputtino::SwitchJoypad::new(&definition);
     /// ```
     pub fn new(device: &DeviceDefinition) -> Result<Self, InputtinoError> {
-        make_device(inputtino_joypad_ps5_create, device).map(|joypad| PS5Joypad {
+        make_device(inputtino_joypad_ps5_create, device).map(Self::from_raw)
+    }
+
+    /// Create a new emulated PS5 DualSense device presented over the given connection.
+    ///
+    /// [`PS5Joypad::new`] always uses Bluetooth.
+    pub fn new_with_connection(
+        device: &DeviceDefinition,
+        connection: PS5Connection,
+    ) -> Result<Self, InputtinoError> {
+        make_device_with(device, |def, eh| unsafe {
+            inputtino_joypad_ps5_create_with_connection(def, connection, eh)
+        })
+        .map(Self::from_raw)
+    }
+
+    fn from_raw(joypad: *mut crate::sys::InputtinoPS5Joypad) -> Self {
+        PS5Joypad {
             joypad,
             on_rumble_fn: std::ptr::null_mut(),
             on_led_fn: std::ptr::null_mut(),
             on_trigger_effect_fn: std::ptr::null_mut(),
-        })
+        }
     }
 
     /// Set the state of all buttons.

--- a/bindings/rust/inputtino/src/lib.rs
+++ b/bindings/rust/inputtino/src/lib.rs
@@ -25,7 +25,7 @@ mod joypad_xbox;
 pub use inputtino_sys::{
     INPUTTINO_JOYPAD_BTN as JoypadButton, INPUTTINO_JOYPAD_MOTION_TYPE as JoypadMotionType,
     INPUTTINO_JOYPAD_STICK_POSITION as JoypadStickPosition, INPUTTINO_MOUSE_BUTTON as MouseButton,
-    BATTERY_STATE as BatteryState,
+    BATTERY_STATE as BatteryState, INPUTTINO_PS5_CONNECTION as PS5Connection,
 };
 
 // Low level automatic c bindings.

--- a/include/inputtino/input.h
+++ b/include/inputtino/input.h
@@ -264,8 +264,19 @@ LIBINPUTTINO_EXPORT void inputtino_joypad_switch_destroy(InputtinoSwitchJoypad *
 struct InputtinoPS5Joypad;
 typedef struct InputtinoPS5Joypad InputtinoPS5Joypad;
 
+enum INPUTTINO_PS5_CONNECTION {
+  PS5_CONNECTION_BLUETOOTH,
+  PS5_CONNECTION_USB
+};
+
+/* Creates a Bluetooth DualSense, see inputtino_joypad_ps5_create_with_connection() */
 LIBINPUTTINO_EXPORT InputtinoPS5Joypad *inputtino_joypad_ps5_create(const InputtinoDeviceDefinition *device,
                                                        const InputtinoErrorHandler *eh);
+
+LIBINPUTTINO_EXPORT InputtinoPS5Joypad *
+inputtino_joypad_ps5_create_with_connection(const InputtinoDeviceDefinition *device,
+                                            enum INPUTTINO_PS5_CONNECTION connection,
+                                            const InputtinoErrorHandler *eh);
 
 LIBINPUTTINO_EXPORT char **inputtino_joypad_ps5_get_nodes(InputtinoPS5Joypad *joypad, int *num_nodes);
 

--- a/include/inputtino/input.hpp
+++ b/include/inputtino/input.hpp
@@ -378,9 +378,14 @@ private:
 
 class PS5Joypad : public Joypad {
 public:
+  /**
+   * @param use_bluetooth present the pad as a Bluetooth (true) or USB (false) DualSense; only the uhid backend honours
+   * this. Some consumers (e.g. Proton, which rewrites Bluetooth DualSense reports) only see full reports over USB.
+   */
   static Result<PS5Joypad>
   create(const DeviceDefinition &device = {
-             .name = "Wolf DualSense (virtual) pad", .vendor_id = 0x054C, .product_id = 0x0CE6, .version = 0x8111});
+             .name = "Wolf DualSense (virtual) pad", .vendor_id = 0x054C, .product_id = 0x0CE6, .version = 0x8111},
+         bool use_bluetooth = true);
   PS5Joypad(PS5Joypad &&j) noexcept : _state(nullptr) {
     std::swap(j._state, _state);
   }

--- a/src/c-bindings/joypad_ps5.cpp
+++ b/src/c-bindings/joypad_ps5.cpp
@@ -3,14 +3,22 @@
 
 InputtinoPS5Joypad *inputtino_joypad_ps5_create(const InputtinoDeviceDefinition *device,
                                                 const InputtinoErrorHandler *eh) {
-  auto joypad_ = inputtino::PS5Joypad::create({
-      .name = device->name ? device->name : "Inputtino virtual device",
-      .vendor_id = device->vendor_id,
-      .product_id = device->product_id,
-      .version = device->version,
-      .device_phys = device->device_phys ? device->device_phys : "00:11:22:33:44:55",
-      .device_uniq = device->device_uniq ? device->device_uniq : "00:11:22:33:44:55",
-  });
+  return inputtino_joypad_ps5_create_with_connection(device, PS5_CONNECTION_BLUETOOTH, eh);
+}
+
+InputtinoPS5Joypad *inputtino_joypad_ps5_create_with_connection(const InputtinoDeviceDefinition *device,
+                                                                enum INPUTTINO_PS5_CONNECTION connection,
+                                                                const InputtinoErrorHandler *eh) {
+  auto joypad_ = inputtino::PS5Joypad::create(
+      {
+          .name = device->name ? device->name : "Inputtino virtual device",
+          .vendor_id = device->vendor_id,
+          .product_id = device->product_id,
+          .version = device->version,
+          .device_phys = device->device_phys ? device->device_phys : "00:11:22:33:44:55",
+          .device_uniq = device->device_uniq ? device->device_uniq : "00:11:22:33:44:55",
+      },
+      connection == PS5_CONNECTION_BLUETOOTH);
   if (joypad_) {
     return reinterpret_cast<InputtinoPS5Joypad *>(new inputtino::PS5Joypad(std::move(*joypad_)));
   } else {

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -239,8 +239,7 @@ PS5Joypad::~PS5Joypad() {
   }
 }
 
-Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device) {
-  bool use_bluetooth = true; // TODO: expose this
+Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device, bool use_bluetooth) {
 
   auto def = uhid::DeviceDefinition{
       .name = device.name,

--- a/src/uhid/joypad_ps5.cpp
+++ b/src/uhid/joypad_ps5.cpp
@@ -126,6 +126,16 @@ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, 
     // TODO: signal error somehow
     break;
   }
+  case UHID_SET_REPORT: {
+    // The kernel blocks the caller until this is answered (and fails it after a timeout), so acknowledge feature
+    // reports we don't act on; some DualSense clients refuse the pad if these writes fail.
+    uhid_event answer{};
+    answer.type = UHID_SET_REPORT_REPLY;
+    answer.u.set_report_reply.id = ev.u.set_report.id;
+    answer.u.set_report_reply.err = 0;
+    uhid::uhid_write(fd, &answer);
+    break;
+  }
   case UHID_OUTPUT: { // This is sent if the HID device driver wants to send raw data to the device
     // Here is where we'll get Rumble and LED events
     // Check the first byte to see if it's a USB or BT report

--- a/src/uinput/joypad_ps.cpp
+++ b/src/uinput/joypad_ps.cpp
@@ -91,7 +91,7 @@ PS5Joypad::~PS5Joypad() {
   }
 }
 
-Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device) {
+Result<PS5Joypad> PS5Joypad::create(const DeviceDefinition &device, bool /* use_bluetooth */) {
   auto joy_el = create_ps_controller(device);
   if (!joy_el) {
     return Error(joy_el.getErrorMessage());


### PR DESCRIPTION
two changes to the uhid PS5 joypad that came up while getting a few games working through moonshine:

- PS5 joypads could only be created as Bluetooth devices. there's now an optional connection type (Bluetooth or USB) in the C++, C and Rust APIs, with Bluetooth staying the default. Bluetooth DualSense input got mangled under Proton for the Dying Light DualSense mod, in my case. presenting the pad over USB avoids it
- `UHID_SET_REPORT` requests were never answered, so the kernel blocked each one until it timed out (~5s) and failed it. some DualSense clients (Outlast Trials, in my case) refuse the controller when these writes fail. feature reports are now acknowledged

tested with moonshine: Dying Light and Outlast Trials both work now. (used LLMs to help debug this)
